### PR TITLE
Add configuration options for ignoring freezing, listening for adds & removes

### DIFF
--- a/peertaskqueue_test.go
+++ b/peertaskqueue_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ipfs/go-peertaskqueue/peertask"
 	"github.com/ipfs/go-peertaskqueue/testutil"
+	peer "github.com/libp2p/go-libp2p-peer"
 )
 
 func TestPushPop(t *testing.T) {
@@ -167,6 +168,50 @@ func TestPeerRepeats(t *testing.T) {
 	}
 }
 
+func TestHooks(t *testing.T) {
+	var peersAdded []string
+	var peersRemoved []string
+	onPeerAdded := func(p peer.ID) {
+		peersAdded = append(peersAdded, p.Pretty())
+	}
+	onPeerRemoved := func(p peer.ID) {
+		peersRemoved = append(peersRemoved, p.Pretty())
+	}
+	ptq := New(OnPeerAddedHook(onPeerAdded), OnPeerRemovedHook(onPeerRemoved))
+	peers := testutil.GeneratePeers(2)
+	a := peers[0]
+	b := peers[1]
+	ptq.PushBlock(a, peertask.Task{Identifier: "1"})
+	ptq.PushBlock(b, peertask.Task{Identifier: "2"})
+	expected := []string{a.Pretty(), b.Pretty()}
+	sort.Strings(expected)
+	sort.Strings(peersAdded)
+	if len(peersAdded) != len(expected) {
+		t.Fatal("Incorrect number of peers added")
+	}
+	for i, s := range peersAdded {
+		if expected[i] != s {
+			t.Fatal("unexpected peer", s, expected[i])
+		}
+	}
+
+	task := ptq.PopBlock()
+	task.Done(task.Tasks)
+	task = ptq.PopBlock()
+	task.Done(task.Tasks)
+	ptq.PopBlock()
+	ptq.PopBlock()
+
+	sort.Strings(peersRemoved)
+	if len(peersRemoved) != len(expected) {
+		t.Fatal("Incorrect number of peers removed")
+	}
+	for i, s := range peersRemoved {
+		if expected[i] != s {
+			t.Fatal("unexpected peer", s, expected[i])
+		}
+	}
+}
 func TestCleaningUpQueues(t *testing.T) {
 	ptq := New()
 


### PR DESCRIPTION
# Goals

Allow peer task queue to be configured in various ways (turn off freezing, hooks to when peers are added and removed)

in service of https://github.com/ipfs/go-bitswap/issues/114 and a more efficient GraphSync