### PR TITLE
fix: only freeze when removing an _active_ task

### DIFF
--- a/peertaskqueue.go
+++ b/peertaskqueue.go
@@ -167,9 +167,7 @@ func (ptq *PeerTaskQueue) PopBlock() *peertask.TaskBlock {
 // Remove removes a task from the queue.
 func (ptq *PeerTaskQueue) Remove(identifier peertask.Identifier, p peer.ID) {
 	ptq.lock.Lock()
-	peerTracker, ok := ptq.peerTrackers[p]
-	if ok {
-		peerTracker.Remove(identifier)
+	if peerTracker, ok := ptq.peerTrackers[p]; ok && peerTracker.Remove(identifier) {
 		// we now also 'freeze' that partner. If they sent us a cancel for a
 		// block we were about to send them, we should wait a short period of time
 		// to make sure we receive any other in-flight cancels before sending

--- a/peertaskqueue_test.go
+++ b/peertaskqueue_test.go
@@ -92,7 +92,7 @@ func TestFreezeUnfreeze(t *testing.T) {
 	// now, pop off four tasks, there should be one from each
 	matchNTasks(t, ptq, 4, a.Pretty(), b.Pretty(), c.Pretty(), d.Pretty())
 
-	ptq.Remove(peertask.Task{Identifier: "1"}, b)
+	ptq.Remove("1", b)
 
 	// b should be frozen, causing it to get skipped in the rotation
 	matchNTasks(t, ptq, 3, a.Pretty(), c.Pretty(), d.Pretty())
@@ -124,7 +124,7 @@ func TestFreezeUnfreezeNoFreezingOption(t *testing.T) {
 	// now, pop off four tasks, there should be one from each
 	matchNTasks(t, ptq, 4, a.Pretty(), b.Pretty(), c.Pretty(), d.Pretty())
 
-	ptq.Remove(peertask.Task{Identifier: "1"}, b)
+	ptq.Remove("1", b)
 
 	// b should be frozen, causing it to get skipped in the rotation
 	matchNTasks(t, ptq, 4, a.Pretty(), b.Pretty(), c.Pretty(), d.Pretty())

--- a/peertracker/peertracker.go
+++ b/peertracker/peertracker.go
@@ -179,12 +179,13 @@ func (p *PeerTracker) PopBlock() *peertask.TaskBlock {
 }
 
 // Remove removes the task with the given identifier from this peers queue
-func (p *PeerTracker) Remove(identifier peertask.Identifier) {
+func (p *PeerTracker) Remove(identifier peertask.Identifier) bool {
 	taskBlock, ok := p.taskMap[identifier]
 	if ok {
 		taskBlock.MarkPrunable(identifier)
 		p.numTasks--
 	}
+	return ok
 }
 
 // Freeze increments the freeze value for this peer. While a peer is frozen


### PR DESCRIPTION
We send cancels when we receive blocks. We don't want to freeze a peer when handling those.