### PR TITLE
fix(peertaskqueue): don't freeze for node that does not exist

### DIFF
--- a/peertaskqueue_test.go
+++ b/peertaskqueue_test.go
@@ -92,7 +92,7 @@ func TestFreezeUnfreeze(t *testing.T) {
 	// now, pop off four tasks, there should be one from each
 	matchNTasks(t, ptq, 4, a.Pretty(), b.Pretty(), c.Pretty(), d.Pretty())
 
-	ptq.Remove(peertask.Task{Identifier: "1"}, b)
+	ptq.Remove("1", b)
 
 	// b should be frozen, causing it to get skipped in the rotation
 	matchNTasks(t, ptq, 3, a.Pretty(), c.Pretty(), d.Pretty())
@@ -100,6 +100,12 @@ func TestFreezeUnfreeze(t *testing.T) {
 	ptq.ThawRound()
 
 	matchNTasks(t, ptq, 1, b.Pretty())
+
+	// remove none existent task
+	ptq.Remove("-1", b)
+
+	// b should not be frozen
+	matchNTasks(t, ptq, 4, a.Pretty(), b.Pretty(), c.Pretty(), d.Pretty())
 
 }
 
@@ -124,7 +130,7 @@ func TestFreezeUnfreezeNoFreezingOption(t *testing.T) {
 	// now, pop off four tasks, there should be one from each
 	matchNTasks(t, ptq, 4, a.Pretty(), b.Pretty(), c.Pretty(), d.Pretty())
 
-	ptq.Remove(peertask.Task{Identifier: "1"}, b)
+	ptq.Remove("1", b)
 
 	// b should be frozen, causing it to get skipped in the rotation
 	matchNTasks(t, ptq, 4, a.Pretty(), b.Pretty(), c.Pretty(), d.Pretty())

--- a/peertracker/peertracker.go
+++ b/peertracker/peertracker.go
@@ -179,12 +179,13 @@ func (p *PeerTracker) PopBlock() *peertask.TaskBlock {
 }
 
 // Remove removes the task with the given identifier from this peers queue
-func (p *PeerTracker) Remove(identifier peertask.Identifier) {
+func (p *PeerTracker) Remove(identifier peertask.Identifier) bool {
 	taskBlock, ok := p.taskMap[identifier]
 	if ok {
 		taskBlock.MarkPrunable(identifier)
 		p.numTasks--
 	}
+	return ok
 }
 
 // Freeze increments the freeze value for this peer. While a peer is frozen


### PR DESCRIPTION
We were not double checking to make sure a node was actually removed in an individual task queue

fix #5 fix #6 