### PR TITLE
Extend peer task queue to work with want-have / want-block

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/ipfs/go-peertaskqueue
 go 1.12
 
 require (
-	github.com/google/uuid v1.1.1 // indirect
 	github.com/ipfs/go-ipfs-pq v0.0.1
 	github.com/libp2p/go-libp2p-core v0.0.1
 	github.com/multiformats/go-multihash v0.0.5 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/ipfs/go-peertaskqueue
 go 1.12
 
 require (
+	github.com/google/uuid v1.1.1 // indirect
 	github.com/ipfs/go-ipfs-pq v0.0.1
 	github.com/libp2p/go-libp2p-core v0.0.1
 	github.com/multiformats/go-multihash v0.0.5 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ipfs/go-peertaskqueue
 go 1.12
 
 require (
-	github.com/ipfs/go-ipfs-pq v0.0.1
+	github.com/ipfs/go-ipfs-pq v0.0.2
 	github.com/libp2p/go-libp2p-core v0.0.1
 	github.com/multiformats/go-multihash v0.0.5 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/gogo/protobuf v1.2.1 h1:/s5zKNz0uPFCZ5hddgPdo2TK2TVrUNMn0OOX8/aZMTE=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
+github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gxed/hashland/keccakpg v0.0.1 h1:wrk3uMNaMxbXiHibbPO4S0ymqJMm41WiudyFSs7UnsU=
 github.com/gxed/hashland/keccakpg v0.0.1/go.mod h1:kRzw3HkwxFU1mpmPP8v1WyQzwdGfmKFJ6tItnhQ67kU=
 github.com/gxed/hashland/murmur3 v0.0.1 h1:SheiaIt0sda5K+8FLz952/1iWS9zrnKsEJaOJu4ZbSc=

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/gxed/hashland/murmur3 v0.0.1 h1:SheiaIt0sda5K+8FLz952/1iWS9zrnKsEJaOJ
 github.com/gxed/hashland/murmur3 v0.0.1/go.mod h1:KjXop02n4/ckmZSnY2+HKcLud/tcmvhST0bie/0lS48=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ipfs/go-cid v0.0.1/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
+github.com/ipfs/go-ipfs-pq v0.0.0-20191101181110-8122fa6a9529 h1:izQqDLe/uSPKe6NYr3FjwnvU0AAg0im/4DLVXplLFUQ=
+github.com/ipfs/go-ipfs-pq v0.0.0-20191101181110-8122fa6a9529/go.mod h1:LWIqQpqfRG3fNc5XsnIhz/wQ2XXGyugQwls7BgUmUfY=
 github.com/ipfs/go-ipfs-pq v0.0.1 h1:zgUotX8dcAB/w/HidJh1zzc1yFq6Vm8J7T2F4itj/RU=
 github.com/ipfs/go-ipfs-pq v0.0.1/go.mod h1:LWIqQpqfRG3fNc5XsnIhz/wQ2XXGyugQwls7BgUmUfY=
 github.com/jbenet/goprocess v0.0.0-20160826012719-b497e2f366b8/go.mod h1:Ly/wlsjFq/qrU3Rar62tu1gASgGw6chQbSh/XgIIXCY=

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/ipfs/go-ipfs-pq v0.0.0-20191101181110-8122fa6a9529 h1:izQqDLe/uSPKe6N
 github.com/ipfs/go-ipfs-pq v0.0.0-20191101181110-8122fa6a9529/go.mod h1:LWIqQpqfRG3fNc5XsnIhz/wQ2XXGyugQwls7BgUmUfY=
 github.com/ipfs/go-ipfs-pq v0.0.1 h1:zgUotX8dcAB/w/HidJh1zzc1yFq6Vm8J7T2F4itj/RU=
 github.com/ipfs/go-ipfs-pq v0.0.1/go.mod h1:LWIqQpqfRG3fNc5XsnIhz/wQ2XXGyugQwls7BgUmUfY=
+github.com/ipfs/go-ipfs-pq v0.0.2 h1:e1vOOW6MuOwG2lqxcLA+wEn93i/9laCY8sXAw76jFOY=
+github.com/ipfs/go-ipfs-pq v0.0.2/go.mod h1:LWIqQpqfRG3fNc5XsnIhz/wQ2XXGyugQwls7BgUmUfY=
 github.com/jbenet/goprocess v0.0.0-20160826012719-b497e2f366b8/go.mod h1:Ly/wlsjFq/qrU3Rar62tu1gASgGw6chQbSh/XgIIXCY=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jrick/logrotate v1.0.0/go.mod h1:LNinyqDIJnpAur+b8yyulnQw/wDuN1+BYKlTRt3OuAQ=

--- a/peertask/peertask.go
+++ b/peertask/peertask.go
@@ -43,6 +43,7 @@ type Task struct {
 	SendDontHave bool
 	EntrySize    int
 	BlockSize    int
+	HaveBlock    bool
 	Uuid         uuid.UUID
 }
 

--- a/peertask/peertask.go
+++ b/peertask/peertask.go
@@ -42,8 +42,10 @@ type Task struct {
 	Topic Topic
 	// Priority of the task
 	Priority int
-	// The size of the task - peers with bigger size queues are higher priority
-	Size int
+	// The size of the task
+	// - peers with most active work are deprioritized
+	// - peers with most pending work are prioritized
+	Work int
 	// Arbitrary data associated with this Task by the client
 	Data Data
 }

--- a/peertask/peertask.go
+++ b/peertask/peertask.go
@@ -47,7 +47,6 @@ type Task struct {
 // It is used internally by the PeerTracker to keep track of tasks.
 type QueueTask struct {
 	Task
-	Removed bool
 	Target  peer.ID
 	created time.Time // created marks the time that the task was added to the queue
 	index   int       // book-keeping field used by the pq container
@@ -66,7 +65,6 @@ func (t *QueueTask) ReplaceWith(replacement *QueueTask) {
 func NewQueueTask(task Task, target peer.ID, created time.Time) *QueueTask {
 	return &QueueTask{
 		Task:    task,
-		Removed: false,
 		Target:  target,
 		created: created,
 	}

--- a/peertask/peertask.go
+++ b/peertask/peertask.go
@@ -5,6 +5,8 @@ import (
 
 	pq "github.com/ipfs/go-ipfs-pq"
 	peer "github.com/libp2p/go-libp2p-core/peer"
+
+	"github.com/google/uuid"
 )
 
 // FIFOCompare is a basic task comparator that returns tasks in the order created.
@@ -41,6 +43,7 @@ type Task struct {
 	IsDontHave   bool
 	SendDontHave bool
 	Size         int
+	Uuid         uuid.UUID
 }
 
 // QueueTask contains a Task, and also some bookkeeping information.

--- a/peertask/peertask.go
+++ b/peertask/peertask.go
@@ -37,13 +37,13 @@ type Identifier interface{}
 
 // Task is a single task to be executed as part of a task block.
 type Task struct {
-	Identifier    Identifier
-	Priority      int
-	IsWantBlock   bool
-	KnowBlockSize bool
-	SendDontHave  bool
-	Size          int
-	Uuid          uuid.UUID
+	Identifier   Identifier
+	Priority     int
+	IsWantBlock  bool
+	SendDontHave bool
+	EntrySize    int
+	BlockSize    int
+	Uuid         uuid.UUID
 }
 
 // QueueTask contains a Task, and also some bookkeeping information.
@@ -55,22 +55,15 @@ type QueueTask struct {
 	index   int       // book-keeping field used by the pq container
 }
 
-// ReplaceWith copies the fields from the given QueueTask into this QueueTask.
-func (t *QueueTask) ReplaceWith(replacement *QueueTask) {
-	t.Priority = replacement.Priority
-	t.IsWantBlock = replacement.IsWantBlock
-	t.SendDontHave = replacement.SendDontHave
-	t.KnowBlockSize = replacement.KnowBlockSize
-	t.Size = replacement.Size
-}
-
 // NewQueueTask creates a new QueueTask from the given Task.
 func NewQueueTask(task Task, target peer.ID, created time.Time) *QueueTask {
-	return &QueueTask{
+	t := &QueueTask{
 		Task:    task,
 		Target:  target,
 		created: created,
 	}
+	t.Uuid = uuid.New()
+	return t
 }
 
 // Index implements pq.Elem.

--- a/peertask/peertask.go
+++ b/peertask/peertask.go
@@ -37,13 +37,13 @@ type Identifier interface{}
 
 // Task is a single task to be executed as part of a task block.
 type Task struct {
-	Identifier   Identifier
-	Priority     int
-	IsWantBlock  bool
-	IsDontHave   bool
-	SendDontHave bool
-	Size         int
-	Uuid         uuid.UUID
+	Identifier    Identifier
+	Priority      int
+	IsWantBlock   bool
+	KnowBlockSize bool
+	SendDontHave  bool
+	Size          int
+	Uuid          uuid.UUID
 }
 
 // QueueTask contains a Task, and also some bookkeeping information.
@@ -60,7 +60,7 @@ func (t *QueueTask) ReplaceWith(replacement *QueueTask) {
 	t.Priority = replacement.Priority
 	t.IsWantBlock = replacement.IsWantBlock
 	t.SendDontHave = replacement.SendDontHave
-	t.IsDontHave = replacement.IsDontHave
+	t.KnowBlockSize = replacement.KnowBlockSize
 	t.Size = replacement.Size
 }
 

--- a/peertask/peertask.go
+++ b/peertask/peertask.go
@@ -37,14 +37,22 @@ type Identifier interface{}
 
 // Task is a single task to be executed as part of a task block.
 type Task struct {
-	Identifier   Identifier
-	Priority     int
-	IsWantBlock  bool
+	// Identifier for the task (may not be unique)
+	Identifier Identifier
+	// Priority of the task
+	Priority int
+	// Tasks can be want-have or want-block
+	IsWantBlock bool
+	// Whether to immediately send a response if the block is not found
 	SendDontHave bool
-	EntrySize    int
-	BlockSize    int
-	HaveBlock    bool
-	Uuid         uuid.UUID
+	// The size that this task will take up in the response message
+	EntrySize int
+	// The size of the block corresponding to the identifier
+	BlockSize int
+	// Whether the block was found
+	HaveBlock bool
+	// Unique ID
+	Uuid uuid.UUID
 }
 
 // QueueTask contains a Task, and also some bookkeeping information.

--- a/peertaskqueue.go
+++ b/peertaskqueue.go
@@ -135,7 +135,7 @@ func (ptq *PeerTaskQueue) PushBlock(to peer.ID, tasks ...peertask.Task) {
 	peerTracker.PushBlock(to, tasks, func(e []peertask.Task) {
 		ptq.lock.Lock()
 		for _, task := range e {
-			peerTracker.TaskDone(task.Identifier)
+			peerTracker.TaskDone(task.Identifier, task.IsBlock)
 		}
 		ptq.pQueue.Update(peerTracker.Index())
 		ptq.lock.Unlock()

--- a/peertaskqueue.go
+++ b/peertaskqueue.go
@@ -151,7 +151,8 @@ func (ptq *PeerTaskQueue) PopTasks(from peer.ID, maxSize int) (peer.ID, []peerta
 	var peerTracker *peertracker.PeerTracker
 
 	// If the peer wasn't specified, choose the highest priority peer
-	if from == "" {
+	popTracker := from == ""
+	if popTracker {
 		peerTracker = ptq.pQueue.Pop().(*peertracker.PeerTracker)
 		if peerTracker == nil {
 			return "", nil
@@ -174,10 +175,12 @@ func (ptq *PeerTaskQueue) PopTasks(from peer.ID, maxSize int) (peer.ID, []peerta
 		delete(ptq.peerTrackers, target)
 		delete(ptq.frozenPeers, target)
 		ptq.callHooks(target, peerRemoved)
-	} else {
-		// If it does have more tasks, put it back into the peer queue
+	} else if popTracker {
+		// If it does have more tasks, and we popped it, put it back into the
+		// peer queue
 		ptq.pQueue.Push(peerTracker)
 	}
+
 	return peerTracker.Target(), out
 }
 

--- a/peertaskqueue.go
+++ b/peertaskqueue.go
@@ -150,7 +150,9 @@ func (ptq *PeerTaskQueue) PushTasks(to peer.ID, tasks ...peertask.Task) {
 }
 
 // PopTasks pops the highest priority tasks from the peer off the queue, up to
-// the given maximum size of those tasks.
+// the given maximum size of those tasks. Note that the first task is always
+// popped off the queue even if it's over maxSize, to prevent large tasks from
+// blocking up the queue.
 func (ptq *PeerTaskQueue) PopTasks(maxSize int) (peer.ID, []*peertask.Task) {
 	ptq.lock.Lock()
 	defer ptq.lock.Unlock()

--- a/peertaskqueue.go
+++ b/peertaskqueue.go
@@ -198,7 +198,7 @@ func (ptq *PeerTaskQueue) TasksDone(to peer.ID, tasks ...peertask.Task) {
 
 	// Tell the peer tracker that the tasks have completed
 	for _, task := range tasks {
-		peerTracker.TaskDone(task.Identifier, task.IsWantBlock)
+		peerTracker.TaskDone(task)
 	}
 
 	// This may affect the peer's position in the peer queue, so update if

--- a/peertaskqueue_test.go
+++ b/peertaskqueue_test.go
@@ -212,7 +212,7 @@ func TestPeerOrder(t *testing.T) {
 	// b: 1 + 3 + 1
 	// c: 2 + 2
 	// No more pending tasks, so next pop should return nothing
-	p, tsk = ptq.PopTasks("", 3)
+	_, tsk = ptq.PopTasks("", 3)
 	if len(tsk) != 0 {
 		t.Fatal("Expected no more tasks")
 	}
@@ -258,7 +258,7 @@ func TestPopSamePeer(t *testing.T) {
 	// b: 1            Pending: [3]
 	// Peer b has smallest active byte size in its queue, so it would be chosen
 	// but we explicitly request peer a again
-	p, tsk = ptq.PopTasks(a, 3)
+	_, tsk = ptq.PopTasks(a, 3)
 	if len(tsk) != 0 {
 		t.Fatal("Expected no tasks (request for peer a tasks)")
 	}
@@ -276,7 +276,7 @@ func TestPopSamePeer(t *testing.T) {
 	// a: 3 + 1
 	// b: 1 + 3
 	// No more pending tasks, so next pop should return nothing
-	p, tsk = ptq.PopTasks("", 3)
+	_, tsk = ptq.PopTasks("", 3)
 	if len(tsk) != 0 {
 		t.Fatal("Expected no more tasks")
 	}

--- a/peertaskqueue_test.go
+++ b/peertaskqueue_test.go
@@ -83,10 +83,10 @@ func TestFreezeUnfreeze(t *testing.T) {
 	// Push 5 blocks to each peer
 	for i := 0; i < 5; i++ {
 		is := fmt.Sprint(i)
-		ptq.PushTasks(a, peertask.Task{Identifier: is, Size: 1})
-		ptq.PushTasks(b, peertask.Task{Identifier: is, Size: 1})
-		ptq.PushTasks(c, peertask.Task{Identifier: is, Size: 1})
-		ptq.PushTasks(d, peertask.Task{Identifier: is, Size: 1})
+		ptq.PushTasks(a, peertask.Task{Identifier: is, EntrySize: 1})
+		ptq.PushTasks(b, peertask.Task{Identifier: is, EntrySize: 1})
+		ptq.PushTasks(c, peertask.Task{Identifier: is, EntrySize: 1})
+		ptq.PushTasks(d, peertask.Task{Identifier: is, EntrySize: 1})
 	}
 
 	// now, pop off four tasks, there should be one from each
@@ -121,10 +121,10 @@ func TestFreezeUnfreezeNoFreezingOption(t *testing.T) {
 
 	for i := 0; i < 5; i++ {
 		is := fmt.Sprint(i)
-		ptq.PushTasks(a, peertask.Task{Identifier: is, Size: 1})
-		ptq.PushTasks(b, peertask.Task{Identifier: is, Size: 1})
-		ptq.PushTasks(c, peertask.Task{Identifier: is, Size: 1})
-		ptq.PushTasks(d, peertask.Task{Identifier: is, Size: 1})
+		ptq.PushTasks(a, peertask.Task{Identifier: is, EntrySize: 1})
+		ptq.PushTasks(b, peertask.Task{Identifier: is, EntrySize: 1})
+		ptq.PushTasks(c, peertask.Task{Identifier: is, EntrySize: 1})
+		ptq.PushTasks(d, peertask.Task{Identifier: is, EntrySize: 1})
 	}
 
 	// now, pop off four tasks, there should be one from each
@@ -144,16 +144,16 @@ func TestPeerOrder(t *testing.T) {
 	b := peers[1]
 	c := peers[2]
 
-	ptq.PushTasks(a, peertask.Task{Identifier: "1", Size: 3, Priority: 3})
-	ptq.PushTasks(a, peertask.Task{Identifier: "2", Size: 1, Priority: 2})
-	ptq.PushTasks(a, peertask.Task{Identifier: "3", Size: 2, Priority: 1})
+	ptq.PushTasks(a, peertask.Task{Identifier: "1", EntrySize: 3, Priority: 3})
+	ptq.PushTasks(a, peertask.Task{Identifier: "2", EntrySize: 1, Priority: 2})
+	ptq.PushTasks(a, peertask.Task{Identifier: "3", EntrySize: 2, Priority: 1})
 
-	ptq.PushTasks(b, peertask.Task{Identifier: "4", Size: 1, Priority: 3})
-	ptq.PushTasks(b, peertask.Task{Identifier: "5", Size: 3, Priority: 2})
-	ptq.PushTasks(b, peertask.Task{Identifier: "6", Size: 1, Priority: 1})
+	ptq.PushTasks(b, peertask.Task{Identifier: "4", EntrySize: 1, Priority: 3})
+	ptq.PushTasks(b, peertask.Task{Identifier: "5", EntrySize: 3, Priority: 2})
+	ptq.PushTasks(b, peertask.Task{Identifier: "6", EntrySize: 1, Priority: 1})
 
-	ptq.PushTasks(c, peertask.Task{Identifier: "7", Size: 2, Priority: 3})
-	ptq.PushTasks(c, peertask.Task{Identifier: "8", Size: 2, Priority: 1})
+	ptq.PushTasks(c, peertask.Task{Identifier: "7", EntrySize: 2, Priority: 3})
+	ptq.PushTasks(c, peertask.Task{Identifier: "8", EntrySize: 2, Priority: 1})
 
 	// All peers have nothing in their active queue, so equal chance of any
 	// peer being chosen
@@ -225,11 +225,11 @@ func TestPopSamePeer(t *testing.T) {
 	a := peers[0]
 	b := peers[1]
 
-	ptq.PushTasks(a, peertask.Task{Identifier: "1", Size: 3, Priority: 2})
-	ptq.PushTasks(a, peertask.Task{Identifier: "2", Size: 1, Priority: 1})
+	ptq.PushTasks(a, peertask.Task{Identifier: "1", EntrySize: 3, Priority: 2})
+	ptq.PushTasks(a, peertask.Task{Identifier: "2", EntrySize: 1, Priority: 1})
 
-	ptq.PushTasks(b, peertask.Task{Identifier: "3", Size: 1, Priority: 2})
-	ptq.PushTasks(b, peertask.Task{Identifier: "4", Size: 3, Priority: 1})
+	ptq.PushTasks(b, peertask.Task{Identifier: "3", EntrySize: 1, Priority: 2})
+	ptq.PushTasks(b, peertask.Task{Identifier: "4", EntrySize: 3, Priority: 1})
 
 	// Neither peers has anything in its active queue, so equal chance of any
 	// peer being chosen

--- a/peertracker/peertracker.go
+++ b/peertracker/peertracker.go
@@ -128,7 +128,8 @@ func (p *PeerTracker) PushTasks(tasks []peertask.Task) {
 
 			// If we now have block size information, update the task with
 			// the new block size
-			if existingTask.BlockSize == 0 && task.BlockSize > 0 {
+			if !existingTask.HaveBlock && task.HaveBlock {
+				existingTask.HaveBlock = task.HaveBlock
 				existingTask.BlockSize = task.BlockSize
 			}
 
@@ -137,15 +138,16 @@ func (p *PeerTracker) PushTasks(tasks []peertask.Task) {
 				// Change the type from want-have to want-block
 				existingTask.IsWantBlock = true
 				// If the want-have was a DONT_HAVE, or the want-block has a size
-				if existingTask.BlockSize == 0 || task.BlockSize > 0 {
+				if !existingTask.HaveBlock || task.HaveBlock {
 					// Update the entry size
+					existingTask.HaveBlock = task.HaveBlock
 					existingTask.EntrySize = task.EntrySize
 				}
 			}
 
 			// If the task is a want-block, make sure the entry size is equal
-			// to the block size
-			if existingTask.IsWantBlock && existingTask.BlockSize > 0 {
+			// to the block size (because we will send the whole block)
+			if existingTask.IsWantBlock && existingTask.HaveBlock {
 				existingTask.EntrySize = existingTask.BlockSize
 			}
 
@@ -271,7 +273,7 @@ func (p *PeerTracker) taskHasMoreInfoThanActiveTasks(task peertask.Task) bool {
 		if task.Identifier == at.Identifier {
 			taskWithIdExists = true
 
-			if at.BlockSize > 0 {
+			if at.HaveBlock {
 				haveSize = true
 			}
 
@@ -294,7 +296,7 @@ func (p *PeerTracker) taskHasMoreInfoThanActiveTasks(task peertask.Task) bool {
 
 	// If there is no size information for the CID and the new task has
 	// size information, the new task is better
-	if !haveSize && task.BlockSize > 0 {
+	if !haveSize && task.HaveBlock {
 		return true
 	}
 

--- a/peertracker/peertracker.go
+++ b/peertracker/peertracker.go
@@ -129,9 +129,9 @@ func (p *PeerTracker) PushTasks(tasks []peertask.Task) {
 			}
 
 			// If we now know the size of the block, update the existing entry
-			if existingTask.IsDontHave && !task.IsDontHave {
+			if !existingTask.KnowBlockSize && task.KnowBlockSize {
 				existingTask.Size = task.Size
-				existingTask.IsDontHave = false
+				existingTask.KnowBlockSize = true
 			}
 
 			// We can replace a want-have with a want-block
@@ -259,7 +259,7 @@ func (p *PeerTracker) taskHasMoreInfoThanActiveTasks(task peertask.Task) bool {
 		if task.Identifier == at.Identifier {
 			taskWithIdExists = true
 
-			if !at.IsDontHave {
+			if at.KnowBlockSize {
 				haveSize = true
 			}
 
@@ -282,7 +282,7 @@ func (p *PeerTracker) taskHasMoreInfoThanActiveTasks(task peertask.Task) bool {
 
 	// If there is no size information for the CID and the new task has
 	// size information, the new task is better
-	if !haveSize && !task.IsDontHave {
+	if !haveSize && task.KnowBlockSize {
 		return true
 	}
 

--- a/peertracker/peertracker.go
+++ b/peertracker/peertracker.go
@@ -3,6 +3,7 @@ package peertracker
 import (
 	"fmt"
 	"sync"
+	"time"
 
 	pq "github.com/ipfs/go-ipfs-pq"
 	"github.com/ipfs/go-peertaskqueue/peertask"
@@ -17,11 +18,10 @@ type PeerTracker struct {
 	// processing
 	// active must be locked around as it will be updated externally
 	activelk    sync.Mutex
-	active      int
-	// activeTasks map[peertask.Identifier]struct{}
+	activeBytes int
 	activeTasks map[string]struct{}
 
-	// total number of task tasks for this task
+	// total number of tasks for this peer
 	numTasks int
 
 	// for the PQ interface
@@ -29,22 +29,20 @@ type PeerTracker struct {
 
 	freezeVal int
 
-	// taskMap map[peertask.Identifier]*peertask.TaskBlock
-	taskMap map[string]*peertask.TaskBlock
+	// Map of task id -> task
+	taskMap map[string]*peertask.QueueTask
 
 	// priority queue of tasks belonging to this peer
-	taskBlockQueue pq.PQ
+	taskQueue pq.PQ
 }
 
 // New creates a new PeerTracker
 func New(target peer.ID) *PeerTracker {
 	return &PeerTracker{
-		target:         target,
-		taskBlockQueue: pq.New(peertask.WrapCompare(peertask.PriorityCompare)),
-		// taskMap:        make(map[peertask.Identifier]*peertask.TaskBlock),
-		// activeTasks:    make(map[peertask.Identifier]struct{}),
-		taskMap:        make(map[string]*peertask.TaskBlock),
-		activeTasks:    make(map[string]struct{}),
+		target:      target,
+		taskQueue:   pq.New(peertask.WrapCompare(peertask.PriorityCompare)),
+		taskMap:     make(map[string]*peertask.QueueTask),
+		activeTasks: make(map[string]struct{}),
 	}
 }
 
@@ -63,6 +61,7 @@ func PeerCompare(a, b pq.Elem) bool {
 		return true
 	}
 
+	// Frozen peers have lowest priority
 	if pa.freezeVal > pb.freezeVal {
 		return false
 	}
@@ -70,35 +69,52 @@ func PeerCompare(a, b pq.Elem) bool {
 		return true
 	}
 
-	if pa.active == pb.active {
-		// sorting by taskQueue.Len() aids in cleaning out trash tasks faster
-		// if we sorted instead by requests, one peer could potentially build up
-		// a huge number of cancelled tasks in the queue resulting in a memory leak
-		return pa.taskBlockQueue.Len() > pb.taskBlockQueue.Len()
+	// having no pending tasks means lowest priority
+	if pa.taskQueue.Len() == 0 {
+		return false
 	}
-	return pa.active < pb.active
+	if pb.taskQueue.Len() == 0 {
+		return true
+	}
+
+	// Choose the peer with the least amount of active data in its queue.
+	// This way we "keep peers busy" by sending them as much data as they can
+	// process.
+	return pa.activeBytes < pb.activeBytes
 }
 
-// StartTask signals that a task was started for this peer.
-func (p *PeerTracker) StartTask(identifier peertask.Identifier, isBlock bool) {
+// startTask signals that a task was started for this peer.
+func (p *PeerTracker) startTask(identifier peertask.Identifier, isWantBlock bool) {
 	p.activelk.Lock()
-	// p.activeTasks[identifier] = struct{}{}
-	p.activeTasks[p.getTaskId(identifier, isBlock)] = struct{}{}
-	p.active++
-	p.activelk.Unlock()
+	defer p.activelk.Unlock()
+
+	taskId := p.getTaskId(identifier, isWantBlock)
+	p.activeTasks[taskId] = struct{}{}
+	task, ok := p.taskMap[taskId]
+	if !ok {
+		panic(fmt.Sprintf("Active task %s not found in task map", taskId))
+	}
+	p.activeBytes += task.Size
 }
 
 // TaskDone signals that a task was completed for this peer.
-func (p *PeerTracker) TaskDone(identifier peertask.Identifier, isBlock bool) {
-	// fmt.Printf("TaskDone() %s-%t\n", identifier, isBlock)
+func (p *PeerTracker) TaskDone(identifier peertask.Identifier, isWantBlock bool) {
 	p.activelk.Lock()
-	// delete(p.activeTasks, identifier)
-	delete(p.activeTasks, p.getTaskId(identifier, isBlock))
-	p.active--
-	if p.active < 0 {
-		panic("more tasks finished than started!")
+	defer p.activelk.Unlock()
+
+	taskId := p.getTaskId(identifier, isWantBlock)
+	delete(p.activeTasks, taskId)
+
+	task, ok := p.taskMap[taskId]
+	if ok && !task.Removed {
+		delete(p.taskMap, taskId)
+		p.numTasks--
+
+		p.activeBytes -= task.Size
+		if p.activeBytes < 0 {
+			panic("more tasks finished than started!")
+		}
 	}
-	p.activelk.Unlock()
 }
 
 // Target returns the peer that this peer tracker tracks tasks for
@@ -110,7 +126,8 @@ func (p *PeerTracker) Target() peer.ID {
 func (p *PeerTracker) IsIdle() bool {
 	p.activelk.Lock()
 	defer p.activelk.Unlock()
-	return p.numTasks == 0 && p.active == 0
+
+	return p.numTasks == 0 && p.activeBytes == 0
 }
 
 // Index implements pq.Elem.
@@ -123,144 +140,115 @@ func (p *PeerTracker) SetIndex(i int) {
 	p.index = i
 }
 
-// PushBlock adds a new block of tasks on to a peers queue from the given
-// peer ID, list of tasks, and task block completion function
-func (p *PeerTracker) PushBlock(target peer.ID, tasks []peertask.Task, done func(e []peertask.Task)) {
+// PushTasks adds a group of tasks onto a peer's queue
+func (p *PeerTracker) PushTasks(tasks []peertask.Task) {
+	now := time.Now()
 
 	p.activelk.Lock()
 	defer p.activelk.Unlock()
 
-	var priority int
-	newTasks := make([]peertask.Task, 0, len(tasks))
-	// fmt.Printf("  PushBlock() %d tasks\n", len(tasks))
 	for _, task := range tasks {
-		taskId := p.getTaskId(task.Identifier, task.IsBlock)
+		qTask := peertask.NewQueueTask(task, p.target, now)
+		taskId := p.getTaskId(task.Identifier, task.IsWantBlock)
 
 		// If the task is currently active (being processed)
-		// if _, ok := p.activeTasks[taskId]; ok {
-		if isActiveTaskBlock, ok := p.isAnyTaskWithIdentifierActive(task.Identifier); ok {
-			// fmt.Printf("    active task %s\n", task.Identifier)
+		if isActiveTaskAWantBlock, ok := p.isAnyTaskWithIdentifierActive(task.Identifier); ok {
 			// We can only replace tasks that are not active.
 			// If the active task could not have been replaced (even if it
 			// wasn't active) by the new task, that means the new task is
 			// not doing anything useful, so skip adding the new task.
-			if isActiveTaskBlock || !task.IsBlock {
+			if isActiveTaskAWantBlock || !task.IsWantBlock {
 				continue
 			}
-		} else {
-			// fmt.Printf("    in-active task %s\n", task.Identifier)
-			// If there is already a task with this Identifier
-			// if taskBlock, ok := p.taskMap[task.Identifier]; ok {
-			if oldTaskId, ok := p.anyQueuedTaskWithIdentifier(task.Identifier); ok {
-				// fmt.Printf("      (existing task %s)\n", task.Identifier)
-				taskBlock, ok := p.taskMap[oldTaskId]
-				if !ok {
-					panic("anyQueuedTaskWithIdentifier() returned non-existent task id")
-				}
+		} else if existingTask, ok := p.anyQueuedTaskWithIdentifier(task.Identifier); ok {
+			// There is already a task with this Identifier, and the task is not active
 
-				// If the new task has a higher priority than the old task block,
-				// move the old task block towards the front of the queue.
-				if task.Priority > taskBlock.Priority {
-					taskBlock.Priority = task.Priority
-					p.taskBlockQueue.Update(taskBlock.Index())
-				}				
-
-				// TODO: Replacing the task may result in the block exceeding the message size limit
-				// Replace the task (if it's replaceable)
-				if taskBlock.ReplaceTask(task) {
-					// Update the mapping from task -> task block
-					if taskId != oldTaskId {
-						p.taskMap[taskId] = taskBlock
-						delete(p.taskMap, oldTaskId)
-					}
-				}
-
-				// If a task with the Identifier exists, we don't need to add
-				// the new task to the queue
-				continue
+			// If the new task has a higher priority than the old task,
+			if task.Priority > existingTask.Priority {
+				// Update the priority and the tasks position in the queue
+				existingTask.Priority = task.Priority
+				p.taskQueue.Update(existingTask.Index())
 			}
-		}
 
-		// The block priority will be set to the highest priority of all the
-		// tasks in the block
-		if task.Priority > priority {
-			priority = task.Priority
-		}
-
-		newTasks = append(newTasks, task)
-	}
-
-	if len(newTasks) == 0 {
-		return
-	}
-
-	// Add the task block to the queue, and create a mapping of
-	// task -> task block
-	taskBlock := peertask.NewTaskBlock(newTasks, priority, target, done)
-	p.taskBlockQueue.Push(taskBlock)
-	for _, task := range newTasks {
-		// p.taskMap[task.Identifier] = taskBlock
-		p.taskMap[p.getTaskId(task.Identifier, task.IsBlock)] = taskBlock
-	}
-	p.numTasks += len(newTasks)
-}
-
-// PopBlock removes a block of tasks from this peers queue
-func (p *PeerTracker) PopBlock() *peertask.TaskBlock {
-	// fmt.Printf("PopBlock()\n")
-	var out *peertask.TaskBlock
-	for p.taskBlockQueue.Len() > 0 && p.freezeVal == 0 {
-		out = p.taskBlockQueue.Pop().(*peertask.TaskBlock)
-
-		for _, task := range out.Tasks {
-			// delete(p.taskMap, task.Identifier)
-			delete(p.taskMap, p.getTaskId(task.Identifier, task.IsBlock))
-		}
-		out.PruneTasks()
-
-		// fmt.Printf("  %d tasks\n", len(out.Tasks))
-		if len(out.Tasks) > 0 {
-			for _, task := range out.Tasks {
-				// fmt.Printf("  StartTask() %s\n", task)
-				p.numTasks--
-				// p.StartTask(task.Identifier)
-				p.StartTask(task.Identifier, task.IsBlock)
+			// If we now know the size of the block, update the existing entry
+			if existingTask.IsDontHave && !task.IsDontHave {
+				existingTask.Size = task.Size
 			}
-		} else {
-			out = nil
+
+			// We can replace a want-have with a want-block
+			if !existingTask.IsWantBlock && task.IsWantBlock {
+				existingTaskId := p.getTaskId(existingTask.Identifier, existingTask.IsWantBlock)
+
+				// Update the tasks's fields
+				existingTask.ReplaceWith(qTask)
+
+				// Update the mapping from task id -> task
+				if taskId != existingTaskId {
+					delete(p.taskMap, existingTaskId)
+					p.taskMap[taskId] = existingTask
+				}
+			}
+
+			// A task with the Identifier exists, so we don't need to add
+			// the new task to the queue
 			continue
 		}
-		break
+
+		// Push the new task onto the queue
+		p.taskMap[taskId] = qTask
+		p.numTasks++
+		p.taskQueue.Push(qTask)
 	}
+}
+
+func (p *PeerTracker) PopTasks(maxSize int) []peertask.Task {
+	var out []peertask.Task
+	size := 0
+	for p.taskQueue.Len() > 0 && p.freezeVal == 0 {
+		// Pop a task off the queue
+		task := p.taskQueue.Pop().(*peertask.QueueTask)
+
+		// If it's been pruned, skip it
+		if task.Removed {
+			delete(p.taskMap, p.getTaskId(task.Identifier, task.IsWantBlock))
+			continue
+		}
+
+		// If the next task is too big for the message
+		if size+task.Size > maxSize {
+			// This task doesn't fit into the message, so push it back onto the
+			// queue.
+			p.taskQueue.Push(task)
+
+			return out
+		}
+
+		out = append(out, task.Task)
+		size = size + task.Size
+
+		// Start the task (this makes it "active")
+		p.startTask(task.Identifier, task.IsWantBlock)
+	}
+
 	return out
 }
 
-// Remove removes the task with the given identifier from this peers queue
+// Remove removes the task with the given identifier from this peer's queue
 func (p *PeerTracker) Remove(identifier peertask.Identifier) bool {
-	// taskBlock, ok := p.taskMap[identifier]
-	// if ok {
-	// 	// taskBlock.MarkPrunable(identifier)
-	// 	taskBlock.MarkPrunable(taskId)
-	// 	p.numTasks--
-	// }
-	// fmt.Printf("Remove() %s\n", identifier)
+	return p.remove(identifier, true) || p.remove(identifier, false)
+}
 
-	taskIdBlock := p.getTaskId(identifier, true)
-	// fmt.Printf("  remove %s\n", taskIdBlock)
-	taskBlockIsBlock, ok := p.taskMap[taskIdBlock]
-	if ok {
-		taskBlockIsBlock.MarkPrunable(taskIdBlock, true)
+func (p *PeerTracker) remove(identifier peertask.Identifier, isWantBlock bool) bool {
+	taskId := p.getTaskId(identifier, isWantBlock)
+	task, ok := p.taskMap[taskId]
+	if ok && !task.Removed {
+		// Note that we don't actually remove the reference from p.taskMap
+		// because the task is still in p.taskQueue. It will eventually get
+		// popped off the queue and cleaned up (in PopTasks())
+		task.Removed = true
 		p.numTasks--
 	}
-
-	taskIdNotBlock := p.getTaskId(identifier, false)
-	// fmt.Printf("  remove %s\n", taskIdNotBlock)
-	taskBlockNotBlock, oknb := p.taskMap[taskIdNotBlock]
-	if oknb {
-		taskBlockNotBlock.MarkPrunable(taskIdNotBlock, false)
-		p.numTasks--
-	}
-	return ok || oknb
+	return ok
 }
 
 // Freeze increments the freeze value for this peer. While a peer is frozen
@@ -286,10 +274,15 @@ func (p *PeerTracker) IsFrozen() bool {
 	return p.freezeVal > 0
 }
 
-func (p *PeerTracker) getTaskId(identifier peertask.Identifier, isBlock bool) string {
-	return fmt.Sprintf("%s-%t", identifier, isBlock)
+// getTaskId gets the task id for a task with the given identifier, of the given type.
+func (p *PeerTracker) getTaskId(identifier peertask.Identifier, isWantBlock bool) string {
+	return fmt.Sprintf("%s-%t", identifier, isWantBlock)
 }
 
+// isAnyTaskWithIdentifierActive indicates if there is an active task with the
+// given identifier. The first return argument indicates the type:
+// true:  want-block
+// false: want-have
 func (p *PeerTracker) isAnyTaskWithIdentifierActive(identifier peertask.Identifier) (bool, bool) {
 	taskIdBlock := p.getTaskId(identifier, true)
 	if _, ok := p.activeTasks[taskIdBlock]; ok {
@@ -303,15 +296,16 @@ func (p *PeerTracker) isAnyTaskWithIdentifierActive(identifier peertask.Identifi
 	return false, false
 }
 
-func (p *PeerTracker) anyQueuedTaskWithIdentifier(identifier peertask.Identifier) (string, bool) {
+// anyQueuedTaskWithIdentifier returns a queued task with the given identifier.
+func (p *PeerTracker) anyQueuedTaskWithIdentifier(identifier peertask.Identifier) (*peertask.QueueTask, bool) {
 	taskIdBlock := p.getTaskId(identifier, true)
-	if _, ok := p.taskMap[taskIdBlock]; ok {
-		return taskIdBlock, true
+	if taskBlock, ok := p.taskMap[taskIdBlock]; ok {
+		return taskBlock, true
 	}
 
 	taskIdNotBlock := p.getTaskId(identifier, false)
-	if _, ok := p.taskMap[taskIdNotBlock]; ok {
-		return taskIdNotBlock, true
+	if taskNotBlock, ok := p.taskMap[taskIdNotBlock]; ok {
+		return taskNotBlock, true
 	}
-	return "", false
+	return nil, false
 }

--- a/peertracker/peertracker.go
+++ b/peertracker/peertracker.go
@@ -1,7 +1,6 @@
 package peertracker
 
 import (
-	"fmt"
 	"sync"
 	"time"
 

--- a/peertracker/peertracker.go
+++ b/peertracker/peertracker.go
@@ -163,6 +163,8 @@ func (p *PeerTracker) PushTasks(tasks []peertask.Task) {
 	}
 }
 
+// PopTasks pops as many tasks as possible up to the given size off the queue
+// in priority order
 func (p *PeerTracker) PopTasks(maxSize int) []peertask.Task {
 	var out []peertask.Task
 	size := 0

--- a/peertracker/peertracker.go
+++ b/peertracker/peertracker.go
@@ -173,17 +173,11 @@ func (p *PeerTracker) PopTasks(targetMinWork int) []*peertask.Task {
 		// Pop the next task off the queue
 		t := p.taskQueue.Pop().(*peertask.QueueTask)
 
-		// Ignore tasks that have been cancelled
-		task, ok := p.pendingTasks[t.Topic]
-		if !ok {
-			continue
-		}
-
 		// Start the task (this makes it "active")
-		p.startTask(&task.Task)
+		p.startTask(&t.Task)
 
-		out = append(out, &task.Task)
-		work += task.Work
+		out = append(out, &t.Task)
+		work += t.Work
 	}
 
 	return out
@@ -221,9 +215,10 @@ func (p *PeerTracker) TaskDone(task *peertask.Task) {
 
 // Remove removes the task with the given topic from this peer's queue
 func (p *PeerTracker) Remove(topic peertask.Topic) bool {
-	_, ok := p.pendingTasks[topic]
+	t, ok := p.pendingTasks[topic]
 	if ok {
 		delete(p.pendingTasks, topic)
+		p.taskQueue.Remove(t.Index())
 	}
 	return ok
 }

--- a/peertracker/peertracker.go
+++ b/peertracker/peertracker.go
@@ -166,7 +166,6 @@ func (p *PeerTracker) PushTasks(tasks []peertask.Task) {
 
 		// Push the new task onto the queue
 		p.pendingTasks[taskId] = qTask
-		// p.numTasks++
 		p.taskQueue.Push(qTask)
 	}
 }

--- a/peertracker/peertracker_test.go
+++ b/peertracker/peertracker_test.go
@@ -22,12 +22,12 @@ func TestPushPop(t *testing.T) {
 
 	tasks := []peertask.Task{
 		peertask.Task{
-			Identifier:    "1",
-			Priority:      1,
-			IsWantBlock:   true,
-			KnowBlockSize: true,
-			SendDontHave:  false,
-			Size:          10,
+			Identifier:   "1",
+			Priority:     1,
+			IsWantBlock:  true,
+			BlockSize:    10,
+			EntrySize:    10,
+			SendDontHave: false,
 		},
 	}
 	tracker.PushTasks(tasks)
@@ -40,34 +40,59 @@ func TestPushPop(t *testing.T) {
 	}
 }
 
+func TestPopNegativeOrZeroSize(t *testing.T) {
+	partner := testutil.GeneratePeers(1)[0]
+	tracker := New(partner)
+
+	tasks := []peertask.Task{
+		peertask.Task{
+			Identifier:   "1",
+			Priority:     1,
+			IsWantBlock:  true,
+			BlockSize:    10,
+			EntrySize:    10,
+			SendDontHave: false,
+		},
+	}
+	tracker.PushTasks(tasks)
+	popped := tracker.PopTasks(-1)
+	if len(popped) != 0 {
+		t.Fatal("Expected 0 tasks")
+	}
+	popped = tracker.PopTasks(0)
+	if len(popped) != 0 {
+		t.Fatal("Expected 0 tasks")
+	}
+}
+
 func TestPushPopSizeAndOrder(t *testing.T) {
 	partner := testutil.GeneratePeers(1)[0]
 	tracker := New(partner)
 
 	tasks := []peertask.Task{
 		peertask.Task{
-			Identifier:    "1",
-			Priority:      10,
-			IsWantBlock:   true,
-			KnowBlockSize: true,
-			SendDontHave:  false,
-			Size:          10,
+			Identifier:   "1",
+			Priority:     10,
+			IsWantBlock:  true,
+			BlockSize:    10,
+			EntrySize:    10,
+			SendDontHave: false,
 		},
 		peertask.Task{
-			Identifier:    "2",
-			Priority:      20,
-			IsWantBlock:   true,
-			KnowBlockSize: true,
-			SendDontHave:  false,
-			Size:          10,
+			Identifier:   "2",
+			Priority:     20,
+			IsWantBlock:  true,
+			BlockSize:    10,
+			EntrySize:    10,
+			SendDontHave: false,
 		},
 		peertask.Task{
-			Identifier:    "3",
-			Priority:      15,
-			IsWantBlock:   true,
-			KnowBlockSize: true,
-			SendDontHave:  false,
-			Size:          10,
+			Identifier:   "3",
+			Priority:     15,
+			IsWantBlock:  true,
+			BlockSize:    10,
+			EntrySize:    10,
+			SendDontHave: false,
 		},
 	}
 	tracker.PushTasks(tasks)
@@ -104,28 +129,28 @@ func TestRemove(t *testing.T) {
 
 	tasks := []peertask.Task{
 		peertask.Task{
-			Identifier:    "1",
-			Priority:      10,
-			IsWantBlock:   true,
-			KnowBlockSize: true,
-			SendDontHave:  false,
-			Size:          10,
+			Identifier:   "1",
+			Priority:     10,
+			IsWantBlock:  true,
+			BlockSize:    10,
+			EntrySize:    10,
+			SendDontHave: false,
 		},
 		peertask.Task{
-			Identifier:    "2",
-			Priority:      20,
-			IsWantBlock:   true,
-			KnowBlockSize: true,
-			SendDontHave:  false,
-			Size:          10,
+			Identifier:   "2",
+			Priority:     20,
+			IsWantBlock:  true,
+			BlockSize:    10,
+			EntrySize:    10,
+			SendDontHave: false,
 		},
 		peertask.Task{
-			Identifier:    "3",
-			Priority:      15,
-			IsWantBlock:   true,
-			KnowBlockSize: true,
-			SendDontHave:  false,
-			Size:          10,
+			Identifier:   "3",
+			Priority:     15,
+			IsWantBlock:  true,
+			BlockSize:    10,
+			EntrySize:    10,
+			SendDontHave: false,
 		},
 	}
 	tracker.PushTasks(tasks)
@@ -145,28 +170,28 @@ func TestRemoveMulti(t *testing.T) {
 
 	tasks := []peertask.Task{
 		peertask.Task{
-			Identifier:    "1",
-			Priority:      10,
-			IsWantBlock:   true,
-			KnowBlockSize: true,
-			SendDontHave:  false,
-			Size:          10,
+			Identifier:   "1",
+			Priority:     10,
+			IsWantBlock:  true,
+			BlockSize:    10,
+			EntrySize:    10,
+			SendDontHave: false,
 		},
 		peertask.Task{
-			Identifier:    "1",
-			Priority:      20,
-			IsWantBlock:   false,
-			KnowBlockSize: true,
-			SendDontHave:  false,
-			Size:          10,
+			Identifier:   "1",
+			Priority:     20,
+			IsWantBlock:  false,
+			BlockSize:    10,
+			EntrySize:    1,
+			SendDontHave: false,
 		},
 		peertask.Task{
-			Identifier:    "2",
-			Priority:      15,
-			IsWantBlock:   true,
-			KnowBlockSize: true,
-			SendDontHave:  false,
-			Size:          10,
+			Identifier:   "2",
+			Priority:     15,
+			IsWantBlock:  true,
+			BlockSize:    10,
+			EntrySize:    10,
+			SendDontHave: false,
 		},
 	}
 	tracker.PushTasks(tasks)
@@ -176,7 +201,7 @@ func TestRemoveMulti(t *testing.T) {
 		t.Fatal("Expected 1 task")
 	}
 	if popped[0].Identifier != "2" {
-		t.Fatal("Expected tasks in order")
+		t.Fatal("Expected remaining task")
 	}
 }
 
@@ -186,28 +211,28 @@ func TestRemoveActive(t *testing.T) {
 
 	tasks := []peertask.Task{
 		peertask.Task{
-			Identifier:    "1",
-			Priority:      10,
-			IsWantBlock:   true,
-			KnowBlockSize: true,
-			SendDontHave:  false,
-			Size:          10,
+			Identifier:   "1",
+			Priority:     10,
+			IsWantBlock:  true,
+			BlockSize:    10,
+			EntrySize:    10,
+			SendDontHave: false,
 		},
 		peertask.Task{
-			Identifier:    "1",
-			Priority:      20,
-			IsWantBlock:   false,
-			KnowBlockSize: true,
-			SendDontHave:  false,
-			Size:          10,
+			Identifier:   "1",
+			Priority:     20,
+			IsWantBlock:  true,
+			BlockSize:    10,
+			EntrySize:    1,
+			SendDontHave: false,
 		},
 		peertask.Task{
-			Identifier:    "2",
-			Priority:      15,
-			IsWantBlock:   true,
-			KnowBlockSize: true,
-			SendDontHave:  false,
-			Size:          10,
+			Identifier:   "2",
+			Priority:     15,
+			IsWantBlock:  true,
+			BlockSize:    10,
+			EntrySize:    10,
+			SendDontHave: false,
 		},
 	}
 
@@ -238,20 +263,20 @@ func TestPushHaveVsBlock(t *testing.T) {
 	partner := testutil.GeneratePeers(1)[0]
 
 	wantHave := peertask.Task{
-		Identifier:    "1",
-		Priority:      10,
-		IsWantBlock:   false,
-		KnowBlockSize: true,
-		SendDontHave:  false,
-		Size:          10,
+		Identifier:   "1",
+		Priority:     10,
+		IsWantBlock:  false,
+		BlockSize:    10,
+		EntrySize:    1,
+		SendDontHave: false,
 	}
 	wantBlock := peertask.Task{
-		Identifier:    "1",
-		Priority:      10,
-		IsWantBlock:   true,
-		KnowBlockSize: true,
-		SendDontHave:  false,
-		Size:          10,
+		Identifier:   "1",
+		Priority:     10,
+		IsWantBlock:  true,
+		BlockSize:    10,
+		EntrySize:    10,
+		SendDontHave: false,
 	}
 
 	runTestCase := func(tasks []peertask.Task, expIsWantBlock bool) {
@@ -282,78 +307,115 @@ func TestPushSizeInfo(t *testing.T) {
 	partner := testutil.GeneratePeers(1)[0]
 
 	wantBlock := peertask.Task{
-		Identifier:    "1",
-		Priority:      10,
-		IsWantBlock:   true,
-		KnowBlockSize: true,
-		SendDontHave:  false,
-		Size:          20,
+		Identifier:   "1",
+		Priority:     10,
+		IsWantBlock:  true,
+		BlockSize:    10,
+		EntrySize:    10,
+		SendDontHave: false,
 	}
 	wantBlockDontHave := peertask.Task{
-		Identifier:    "1",
-		Priority:      10,
-		IsWantBlock:   true,
-		KnowBlockSize: false,
-		SendDontHave:  false,
-		Size:          10,
+		Identifier:   "1",
+		Priority:     10,
+		IsWantBlock:  true,
+		BlockSize:    0,
+		EntrySize:    2,
+		SendDontHave: false,
 	}
 	wantHave := peertask.Task{
-		Identifier:    "1",
-		Priority:      10,
-		IsWantBlock:   false,
-		KnowBlockSize: true,
-		SendDontHave:  false,
-		Size:          30,
+		Identifier:   "1",
+		Priority:     10,
+		IsWantBlock:  false,
+		BlockSize:    10,
+		EntrySize:    1,
+		SendDontHave: false,
 	}
 	wantHaveDontHave := peertask.Task{
-		Identifier:    "1",
-		Priority:      10,
-		IsWantBlock:   false,
-		KnowBlockSize: false,
-		SendDontHave:  false,
-		Size:          10,
+		Identifier:   "1",
+		Priority:     10,
+		IsWantBlock:  false,
+		BlockSize:    0,
+		EntrySize:    1,
+		SendDontHave: false,
 	}
 
-	runTestCase := func(tasks []peertask.Task, expSize int) {
+	runTestCase := func(tasks []peertask.Task, expEntrySize int, expBlockSize int, expIsWantBlock bool) {
 		tracker := New(partner)
 		tracker.PushTasks(tasks)
 		popped := tracker.PopTasks(100)
 		if len(popped) != 1 {
 			t.Fatalf("Expected 1 task, received %d tasks", len(popped))
 		}
-		if popped[0].Size != expSize {
-			t.Fatalf("Expected task.Size to be %d, received %d", expSize, popped[0].Size)
+		if popped[0].EntrySize != expEntrySize {
+			t.Fatalf("Expected task.EntrySize to be %d, received %d", expEntrySize, popped[0].EntrySize)
+		}
+		if popped[0].BlockSize != expBlockSize {
+			t.Fatalf("Expected task.EntrySize to be %d, received %d", expBlockSize, popped[0].BlockSize)
+		}
+		if popped[0].IsWantBlock != expIsWantBlock {
+			t.Fatalf("Expected task.IsWantBlock to be %t, received %t", expIsWantBlock, popped[0].IsWantBlock)
 		}
 	}
 
+	isWantBlock := true
+	isWantHave := false
+
+	// want-block (DONT_HAVE) should have no effect on existing want-block (DONT_HAVE)
+	runTestCase([]peertask.Task{wantBlockDontHave, wantBlockDontHave}, wantBlockDontHave.EntrySize, wantBlockDontHave.BlockSize, isWantBlock)
+	// want-have (DONT_HAVE) should have no effect on existing want-block (DONT_HAVE)
+	runTestCase([]peertask.Task{wantBlockDontHave, wantHaveDontHave}, wantBlockDontHave.EntrySize, wantBlockDontHave.BlockSize, isWantBlock)
 	// want-block with size should update existing want-block (DONT_HAVE)
-	runTestCase([]peertask.Task{wantBlockDontHave, wantBlock}, wantBlock.Size)
+	runTestCase([]peertask.Task{wantBlockDontHave, wantBlock}, wantBlock.EntrySize, wantBlock.BlockSize, isWantBlock)
+	// want-have with size should update existing want-block (DONT_HAVE) size,
+	// but leave it as a want-block (ie should not change it to want-have)
+	runTestCase([]peertask.Task{wantBlockDontHave, wantHave}, wantHave.BlockSize, wantHave.BlockSize, isWantBlock)
+
 	// want-block (DONT_HAVE) size should not update existing want-block with size
-	runTestCase([]peertask.Task{wantBlock, wantBlockDontHave}, wantBlock.Size)
+	runTestCase([]peertask.Task{wantBlock, wantBlockDontHave}, wantBlock.EntrySize, wantBlock.BlockSize, isWantBlock)
+	// want-have (DONT_HAVE) should have no effect on existing want-block with size
+	runTestCase([]peertask.Task{wantBlock, wantHaveDontHave}, wantBlock.EntrySize, wantBlock.BlockSize, isWantBlock)
+	// want-block with size should have no effect on existing want-block with size
+	runTestCase([]peertask.Task{wantBlock, wantBlock}, wantBlock.EntrySize, wantBlock.BlockSize, isWantBlock)
+	// want-have with size should have no effect on existing want-block with size
+	runTestCase([]peertask.Task{wantBlock, wantHave}, wantBlock.EntrySize, wantBlock.BlockSize, isWantBlock)
+
+	// want-block (DONT_HAVE) should update type and entry size of existing want-have (DONT_HAVE)
+	runTestCase([]peertask.Task{wantHaveDontHave, wantBlockDontHave}, wantBlockDontHave.EntrySize, wantBlockDontHave.BlockSize, isWantBlock)
+	// want-have (DONT_HAVE) should have no effect on existing want-have (DONT_HAVE)
+	runTestCase([]peertask.Task{wantHaveDontHave, wantHaveDontHave}, wantHaveDontHave.EntrySize, wantHaveDontHave.BlockSize, isWantHave)
+	// want-block with size should update existing want-have (DONT_HAVE)
+	runTestCase([]peertask.Task{wantHaveDontHave, wantBlock}, wantBlock.EntrySize, wantBlock.BlockSize, isWantBlock)
 	// want-have with size should update existing want-have (DONT_HAVE)
-	runTestCase([]peertask.Task{wantHaveDontHave, wantHave}, wantHave.Size)
+	runTestCase([]peertask.Task{wantHaveDontHave, wantHave}, wantHave.EntrySize, wantHave.BlockSize, isWantHave)
+
+	// want-block (DONT_HAVE) should update type and entry size of existing want-have with size
+	runTestCase([]peertask.Task{wantHave, wantBlockDontHave}, wantHave.BlockSize, wantHave.BlockSize, isWantBlock)
 	// want-have (DONT_HAVE) should not update existing want-have with size
-	runTestCase([]peertask.Task{wantHave, wantHaveDontHave}, wantHave.Size)
+	runTestCase([]peertask.Task{wantHave, wantHaveDontHave}, wantHave.EntrySize, wantHave.BlockSize, isWantHave)
+	// want-block with size should update type and entry size of existing want-have with size
+	runTestCase([]peertask.Task{wantHave, wantBlock}, wantBlock.EntrySize, wantBlock.BlockSize, isWantBlock)
+	// want-have should have no effect on existing want-have
+	runTestCase([]peertask.Task{wantHave, wantHave}, wantHave.EntrySize, wantHave.BlockSize, isWantHave)
 }
 
 func TestPushHaveVsBlockActive(t *testing.T) {
 	partner := testutil.GeneratePeers(1)[0]
 
-	wantHave := peertask.Task{
-		Identifier:    "1",
-		Priority:      10,
-		IsWantBlock:   false,
-		KnowBlockSize: true,
-		SendDontHave:  false,
-		Size:          10,
-	}
 	wantBlock := peertask.Task{
-		Identifier:    "1",
-		Priority:      10,
-		IsWantBlock:   true,
-		KnowBlockSize: true,
-		SendDontHave:  false,
-		Size:          10,
+		Identifier:   "1",
+		Priority:     10,
+		IsWantBlock:  true,
+		BlockSize:    10,
+		EntrySize:    10,
+		SendDontHave: false,
+	}
+	wantHave := peertask.Task{
+		Identifier:   "1",
+		Priority:     10,
+		IsWantBlock:  false,
+		BlockSize:    10,
+		EntrySize:    1,
+		SendDontHave: false,
 	}
 
 	runTestCase := func(tasks []peertask.Task, expCount int) {
@@ -384,92 +446,123 @@ func TestPushSizeInfoActive(t *testing.T) {
 	partner := testutil.GeneratePeers(1)[0]
 
 	wantBlock := peertask.Task{
-		Identifier:    "1",
-		Priority:      10,
-		IsWantBlock:   true,
-		KnowBlockSize: true,
-		SendDontHave:  false,
-		Size:          10,
+		Identifier:   "1",
+		Priority:     10,
+		IsWantBlock:  true,
+		BlockSize:    10,
+		EntrySize:    10,
+		SendDontHave: false,
 	}
 	wantBlockDontHave := peertask.Task{
-		Identifier:    "1",
-		Priority:      10,
-		IsWantBlock:   true,
-		KnowBlockSize: false,
-		SendDontHave:  false,
-		Size:          10,
+		Identifier:   "1",
+		Priority:     10,
+		IsWantBlock:  true,
+		BlockSize:    0,
+		EntrySize:    2,
+		SendDontHave: false,
 	}
 	wantHave := peertask.Task{
-		Identifier:    "1",
-		Priority:      10,
-		IsWantBlock:   false,
-		KnowBlockSize: true,
-		SendDontHave:  false,
-		Size:          10,
+		Identifier:   "1",
+		Priority:     10,
+		IsWantBlock:  false,
+		BlockSize:    10,
+		EntrySize:    1,
+		SendDontHave: false,
 	}
 	wantHaveDontHave := peertask.Task{
-		Identifier:    "1",
-		Priority:      10,
-		IsWantBlock:   false,
-		KnowBlockSize: false,
-		SendDontHave:  false,
-		Size:          10,
+		Identifier:   "1",
+		Priority:     10,
+		IsWantBlock:  false,
+		BlockSize:    0,
+		EntrySize:    1,
+		SendDontHave: false,
 	}
 
-	runTestCase := func(tasks []peertask.Task, expCount int) {
+	runTestCase := func(tasks []peertask.Task, expTasks []peertask.Task) {
 		tracker := New(partner)
 		var popped []peertask.Task
 		for _, task := range tasks {
 			// Push the task
 			tracker.PushTasks([]peertask.Task{task})
 			// Pop the task (which makes it active)
-			popped = append(popped, tracker.PopTasks(20)...)
+			popped = append(popped, tracker.PopTasks(100)...)
 		}
-		if len(popped) != expCount {
-			t.Fatalf("Expected %d tasks, received %d tasks", expCount, len(popped))
+		if len(popped) != len(expTasks) {
+			t.Fatalf("Expected %d tasks, received %d tasks", len(expTasks), len(popped))
+		}
+		for i, task := range popped {
+			if task.IsWantBlock != expTasks[i].IsWantBlock {
+				t.Fatalf("Expected IsWantBlock to be %t, received %t", expTasks[i].IsWantBlock, task.IsWantBlock)
+			}
+			if task.EntrySize != expTasks[i].EntrySize {
+				t.Fatalf("Expected Size to be %d, received %d", expTasks[i].EntrySize, task.EntrySize)
+			}
 		}
 	}
 
-	// want-block with size should be added if there is existing want-block (DONT_HAVE)
-	runTestCase([]peertask.Task{wantBlockDontHave, wantBlock}, 2)
-	// want-block (DONT_HAVE) should not be added if there is existing want-block with size
-	runTestCase([]peertask.Task{wantBlock, wantBlockDontHave}, 1)
-	// want-block (DONT_HAVE) should not be added if there is existing want-block (DONT_HAVE)
-	runTestCase([]peertask.Task{wantBlockDontHave, wantBlockDontHave}, 1)
-	// want-have with size should be added if there is existing want-have (DONT_HAVE)
-	runTestCase([]peertask.Task{wantHaveDontHave, wantHave}, 2)
-	// want-have (DONT_HAVE) should not be added if there is existing want-have with size
-	runTestCase([]peertask.Task{wantHave, wantHaveDontHave}, 1)
-	// want-have (DONT_HAVE) should not be added if there is existing want-have (DONT_HAVE)
-	runTestCase([]peertask.Task{wantHaveDontHave, wantHaveDontHave}, 1)
+	// second want-block (DONT_HAVE) should be ignored
+	runTestCase([]peertask.Task{wantBlockDontHave, wantBlockDontHave}, []peertask.Task{wantBlockDontHave})
+	// want-have (DONT_HAVE) should be ignored if there is existing active want-block (DONT_HAVE)
+	runTestCase([]peertask.Task{wantBlockDontHave, wantHaveDontHave}, []peertask.Task{wantBlockDontHave})
+	// want-block with size should be added if there is existing active want-block (DONT_HAVE)
+	runTestCase([]peertask.Task{wantBlockDontHave, wantBlock}, []peertask.Task{wantBlockDontHave, wantBlock})
+	// want-have with size should be added if there is existing active want-block (DONT_HAVE)
+	runTestCase([]peertask.Task{wantBlockDontHave, wantHave}, []peertask.Task{wantBlockDontHave, wantHave})
+
+	// want-block (DONT_HAVE) should be added if there is existing active want-have (DONT_HAVE)
+	runTestCase([]peertask.Task{wantHaveDontHave, wantBlockDontHave}, []peertask.Task{wantHaveDontHave, wantBlockDontHave})
+	// want-have (DONT_HAVE) should be ignored if there is existing active want-have (DONT_HAVE)
+	runTestCase([]peertask.Task{wantHaveDontHave, wantHaveDontHave}, []peertask.Task{wantHaveDontHave})
+	// want-block with size should be added if there is existing active want-have (DONT_HAVE)
+	runTestCase([]peertask.Task{wantHaveDontHave, wantBlock}, []peertask.Task{wantHaveDontHave, wantBlock})
+	// want-have with size should be added if there is existing active want-have (DONT_HAVE)
+	runTestCase([]peertask.Task{wantHaveDontHave, wantHave}, []peertask.Task{wantHaveDontHave, wantHave})
+
+	// want-block (DONT_HAVE) should be ignored if there is existing active want-block with size
+	runTestCase([]peertask.Task{wantBlock, wantBlockDontHave}, []peertask.Task{wantBlock})
+	// want-have (DONT_HAVE) should be ignored if there is existing active want-block with size
+	runTestCase([]peertask.Task{wantBlock, wantHaveDontHave}, []peertask.Task{wantBlock})
+	// second want-block with size should be ignored
+	runTestCase([]peertask.Task{wantBlock, wantBlock}, []peertask.Task{wantBlock})
+	// want-have with size should be ignored if there is existing active want-block with size
+	runTestCase([]peertask.Task{wantBlock, wantHave}, []peertask.Task{wantBlock})
+
+	// want-block (DONT_HAVE) should be added if there is existing active want-have with size
+	runTestCase([]peertask.Task{wantHave, wantBlockDontHave}, []peertask.Task{wantHave, wantBlockDontHave})
+	// want-have (DONT_HAVE) should be ignored if there is existing active want-have with size
+	runTestCase([]peertask.Task{wantHave, wantHaveDontHave}, []peertask.Task{wantHave})
+	// second want-have with size should be ignored
+	runTestCase([]peertask.Task{wantHave, wantHave}, []peertask.Task{wantHave})
+	// want-block with size should be added if there is existing active want-have with size
+	runTestCase([]peertask.Task{wantHave, wantBlock}, []peertask.Task{wantHave, wantBlock})
 }
 
 func TestReplaceTaskThatIsActiveAndPending(t *testing.T) {
 	partner := testutil.GeneratePeers(1)[0]
 
 	wantBlock := peertask.Task{
-		Identifier:    "1",
-		Priority:      10,
-		IsWantBlock:   true,
-		KnowBlockSize: true,
-		SendDontHave:  false,
-		Size:          10,
+		Identifier:   "1",
+		Priority:     10,
+		IsWantBlock:  true,
+		BlockSize:    10,
+		EntrySize:    10,
+		SendDontHave: false,
 	}
 	wantHave := peertask.Task{
-		Identifier:    "1",
-		Priority:      10,
-		IsWantBlock:   false,
-		KnowBlockSize: true,
-		SendDontHave:  false,
-		Size:          10,
+		Identifier:   "1",
+		Priority:     10,
+		IsWantBlock:  false,
+		BlockSize:    10,
+		EntrySize:    1,
+		SendDontHave: false,
 	}
 	wantHaveDontHave := peertask.Task{
-		Identifier:    "1",
-		Priority:      10,
-		IsWantBlock:   false,
-		KnowBlockSize: false,
-		SendDontHave:  false,
-		Size:          10,
+		Identifier:   "1",
+		Priority:     10,
+		IsWantBlock:  false,
+		BlockSize:    0,
+		EntrySize:    1,
+		SendDontHave: false,
 	}
 
 	tracker := New(partner)
@@ -487,7 +580,7 @@ func TestReplaceTaskThatIsActiveAndPending(t *testing.T) {
 	// Push a want-block (should replace the pending want-have)
 	tracker.PushTasks([]peertask.Task{wantBlock})
 
-	popped = tracker.PopTasks(20)
+	popped = tracker.PopTasks(100)
 	if len(popped) != 1 {
 		t.Fatalf("Expected 1 task to be popped, received %d tasks", len(popped))
 	}
@@ -499,21 +592,21 @@ func TestReplaceTaskThatIsActiveAndPending(t *testing.T) {
 func TestTaskDone(t *testing.T) {
 	partner := testutil.GeneratePeers(1)[0]
 
-	wantHave := peertask.Task{
-		Identifier:    "1",
-		Priority:      10,
-		IsWantBlock:   false,
-		KnowBlockSize: true,
-		SendDontHave:  false,
-		Size:          10,
-	}
 	wantBlock := peertask.Task{
-		Identifier:    "1",
-		Priority:      10,
-		IsWantBlock:   true,
-		KnowBlockSize: true,
-		SendDontHave:  false,
-		Size:          10,
+		Identifier:   "1",
+		Priority:     10,
+		IsWantBlock:  true,
+		BlockSize:    10,
+		EntrySize:    10,
+		SendDontHave: false,
+	}
+	wantHave := peertask.Task{
+		Identifier:   "1",
+		Priority:     10,
+		IsWantBlock:  false,
+		BlockSize:    10,
+		EntrySize:    1,
+		SendDontHave: false,
 	}
 
 	runTestCase := func(tasks []peertask.Task, expCount int) {

--- a/peertracker/peertracker_test.go
+++ b/peertracker/peertracker_test.go
@@ -1,0 +1,430 @@
+package peertracker
+
+import (
+	"testing"
+
+	"github.com/ipfs/go-peertaskqueue/peertask"
+	"github.com/ipfs/go-peertaskqueue/testutil"
+)
+
+func TestEmpty(t *testing.T) {
+	partner := testutil.GeneratePeers(1)[0]
+	tracker := New(partner)
+
+	if len(tracker.PopTasks(100)) != 0 {
+		t.Fatal("Expected no tasks")
+	}
+}
+
+func TestPushPop(t *testing.T) {
+	partner := testutil.GeneratePeers(1)[0]
+	tracker := New(partner)
+
+	tasks := []peertask.Task{
+		peertask.Task{
+			Identifier:   "1",
+			Priority:     1,
+			IsWantBlock:  true,
+			IsDontHave:   false,
+			SendDontHave: false,
+			Size:         10,
+		},
+	}
+	tracker.PushTasks(tasks)
+	popped := tracker.PopTasks(100)
+	if len(popped) != 1 {
+		t.Fatal("Expected 1 task")
+	}
+	if popped[0].Identifier != "1" {
+		t.Fatal("Expected same task")
+	}
+}
+
+func TestPushPopSizeAndOrder(t *testing.T) {
+	partner := testutil.GeneratePeers(1)[0]
+	tracker := New(partner)
+
+	tasks := []peertask.Task{
+		peertask.Task{
+			Identifier:   "1",
+			Priority:     10,
+			IsWantBlock:  true,
+			IsDontHave:   false,
+			SendDontHave: false,
+			Size:         10,
+		},
+		peertask.Task{
+			Identifier:   "2",
+			Priority:     20,
+			IsWantBlock:  true,
+			IsDontHave:   false,
+			SendDontHave: false,
+			Size:         10,
+		},
+		peertask.Task{
+			Identifier:   "3",
+			Priority:     15,
+			IsWantBlock:  true,
+			IsDontHave:   false,
+			SendDontHave: false,
+			Size:         10,
+		},
+	}
+	tracker.PushTasks(tasks)
+	popped := tracker.PopTasks(5)
+	if len(popped) != 0 {
+		t.Fatal("Expected 0 tasks")
+	}
+
+	popped = tracker.PopTasks(10)
+	if len(popped) != 1 {
+		t.Fatal("Expected 1 task")
+	}
+	if popped[0].Identifier != "2" {
+		t.Fatal("Expected tasks in order")
+	}
+
+	popped = tracker.PopTasks(100)
+	if len(popped) != 2 {
+		t.Fatal("Expected 2 tasks")
+	}
+	if popped[0].Identifier != "3" || popped[1].Identifier != "1" {
+		t.Fatal("Expected tasks in order")
+	}
+
+	popped = tracker.PopTasks(100)
+	if len(popped) != 0 {
+		t.Fatal("Expected 0 tasks")
+	}
+}
+
+func TestRemove(t *testing.T) {
+	partner := testutil.GeneratePeers(1)[0]
+	tracker := New(partner)
+
+	tasks := []peertask.Task{
+		peertask.Task{
+			Identifier:   "1",
+			Priority:     10,
+			IsWantBlock:  true,
+			IsDontHave:   false,
+			SendDontHave: false,
+			Size:         10,
+		},
+		peertask.Task{
+			Identifier:   "2",
+			Priority:     20,
+			IsWantBlock:  true,
+			IsDontHave:   false,
+			SendDontHave: false,
+			Size:         10,
+		},
+		peertask.Task{
+			Identifier:   "3",
+			Priority:     15,
+			IsWantBlock:  true,
+			IsDontHave:   false,
+			SendDontHave: false,
+			Size:         10,
+		},
+	}
+	tracker.PushTasks(tasks)
+	tracker.Remove("2")
+	popped := tracker.PopTasks(100)
+	if len(popped) != 2 {
+		t.Fatal("Expected 2 tasks")
+	}
+	if popped[0].Identifier != "3" || popped[1].Identifier != "1" {
+		t.Fatal("Expected tasks in order")
+	}
+}
+
+func TestRemoveMulti(t *testing.T) {
+	partner := testutil.GeneratePeers(1)[0]
+	tracker := New(partner)
+
+	tasks := []peertask.Task{
+		peertask.Task{
+			Identifier:   "1",
+			Priority:     10,
+			IsWantBlock:  true,
+			IsDontHave:   false,
+			SendDontHave: false,
+			Size:         10,
+		},
+		peertask.Task{
+			Identifier:   "1",
+			Priority:     20,
+			IsWantBlock:  false,
+			IsDontHave:   false,
+			SendDontHave: false,
+			Size:         10,
+		},
+		peertask.Task{
+			Identifier:   "2",
+			Priority:     15,
+			IsWantBlock:  true,
+			IsDontHave:   false,
+			SendDontHave: false,
+			Size:         10,
+		},
+	}
+	tracker.PushTasks(tasks)
+	tracker.Remove("1")
+	popped := tracker.PopTasks(100)
+	if len(popped) != 1 {
+		t.Fatal("Expected 1 task")
+	}
+	if popped[0].Identifier != "2" {
+		t.Fatal("Expected tasks in order")
+	}
+}
+
+func TestRemoveActive(t *testing.T) {
+	partner := testutil.GeneratePeers(1)[0]
+	tracker := New(partner)
+
+	tasks := []peertask.Task{
+		peertask.Task{
+			Identifier:   "1",
+			Priority:     10,
+			IsWantBlock:  true,
+			IsDontHave:   false,
+			SendDontHave: false,
+			Size:         10,
+		},
+		peertask.Task{
+			Identifier:   "1",
+			Priority:     20,
+			IsWantBlock:  false,
+			IsDontHave:   false,
+			SendDontHave: false,
+			Size:         10,
+		},
+		peertask.Task{
+			Identifier:   "2",
+			Priority:     15,
+			IsWantBlock:  true,
+			IsDontHave:   false,
+			SendDontHave: false,
+			Size:         10,
+		},
+	}
+
+	tracker.PushTasks(tasks)
+
+	// Pop highest priority task, ie ID "1" want-have
+	// This makes the task active
+	popped := tracker.PopTasks(10)
+	if len(popped) != 1 {
+		t.Fatal("Expected 1 task")
+	}
+	if popped[0].Identifier != "1" {
+		t.Fatal("Expected tasks in order")
+	}
+
+	// Remove all tasks with ID "1"
+	tracker.Remove("1")
+	popped = tracker.PopTasks(100)
+	if len(popped) != 1 {
+		t.Fatal("Expected 1 task")
+	}
+	if popped[0].Identifier != "2" {
+		t.Fatal("Expected tasks in order")
+	}
+}
+
+func TestPushHaveVsBlock(t *testing.T) {
+	partner := testutil.GeneratePeers(1)[0]
+
+	wantHave := peertask.Task{
+		Identifier:   "1",
+		Priority:     10,
+		IsWantBlock:  false,
+		IsDontHave:   false,
+		SendDontHave: false,
+		Size:         10,
+	}
+	wantBlock := peertask.Task{
+		Identifier:   "1",
+		Priority:     10,
+		IsWantBlock:  true,
+		IsDontHave:   false,
+		SendDontHave: false,
+		Size:         10,
+	}
+
+	runTestCase := func(tasks []peertask.Task, expIsWantBlock bool) {
+		tracker := New(partner)
+		tracker.PushTasks(tasks)
+		popped := tracker.PopTasks(100)
+		if len(popped) != 1 {
+			t.Fatalf("Expected 1 task, received %d tasks", len(popped))
+		}
+		if popped[0].IsWantBlock != expIsWantBlock {
+			t.Fatalf("Expected task.IsWantBlock to be %t, received %t", expIsWantBlock, popped[0].IsWantBlock)
+		}
+	}
+	const wantBlockType = true
+	const wantHaveType = false
+
+	// should ignore second want-have
+	runTestCase([]peertask.Task{wantHave, wantHave}, wantHaveType)
+	// should ignore second want-block
+	runTestCase([]peertask.Task{wantBlock, wantBlock}, wantBlockType)
+	// want-have does not overwrite want-block
+	runTestCase([]peertask.Task{wantBlock, wantHave}, wantBlockType)
+	// want-block overwrites want-have
+	runTestCase([]peertask.Task{wantHave, wantBlock}, wantBlockType)
+}
+
+func TestPushSizeInfo(t *testing.T) {
+	partner := testutil.GeneratePeers(1)[0]
+
+	wantBlock := peertask.Task{
+		Identifier:   "1",
+		Priority:     10,
+		IsWantBlock:  true,
+		IsDontHave:   false,
+		SendDontHave: false,
+		Size:         20,
+	}
+	wantBlockDontHave := peertask.Task{
+		Identifier:   "1",
+		Priority:     10,
+		IsWantBlock:  true,
+		IsDontHave:   true,
+		SendDontHave: false,
+		Size:         10,
+	}
+	wantHave := peertask.Task{
+		Identifier:   "1",
+		Priority:     10,
+		IsWantBlock:  false,
+		IsDontHave:   false,
+		SendDontHave: false,
+		Size:         30,
+	}
+	wantHaveDontHave := peertask.Task{
+		Identifier:   "1",
+		Priority:     10,
+		IsWantBlock:  false,
+		IsDontHave:   true,
+		SendDontHave: false,
+		Size:         10,
+	}
+
+	runTestCase := func(tasks []peertask.Task, expSize int) {
+		tracker := New(partner)
+		tracker.PushTasks(tasks)
+		popped := tracker.PopTasks(100)
+		if len(popped) != 1 {
+			t.Fatalf("Expected 1 task, received %d tasks", len(popped))
+		}
+		if popped[0].Size != expSize {
+			t.Fatalf("Expected task.Size to be %d, received %d", expSize, popped[0].Size)
+		}
+	}
+
+	// want-block with size should update existing want-block (DONT_HAVE)
+	runTestCase([]peertask.Task{wantBlockDontHave, wantBlock}, wantBlock.Size)
+	// want-block (DONT_HAVE) size should not update existing want-block with size
+	runTestCase([]peertask.Task{wantBlock, wantBlockDontHave}, wantBlock.Size)
+	// want-have with size should update existing want-have (DONT_HAVE)
+	runTestCase([]peertask.Task{wantHaveDontHave, wantHave}, wantHave.Size)
+	// want-have (DONT_HAVE) should not update existing want-have with size
+	runTestCase([]peertask.Task{wantHave, wantHaveDontHave}, wantHave.Size)
+}
+
+func TestPushHaveVsBlockActive(t *testing.T) {
+	partner := testutil.GeneratePeers(1)[0]
+
+	wantHave := peertask.Task{
+		Identifier:   "1",
+		Priority:     10,
+		IsWantBlock:  false,
+		IsDontHave:   false,
+		SendDontHave: false,
+		Size:         10,
+	}
+	wantBlock := peertask.Task{
+		Identifier:   "1",
+		Priority:     10,
+		IsWantBlock:  true,
+		IsDontHave:   false,
+		SendDontHave: false,
+		Size:         10,
+	}
+
+	runTestCase := func(tasks []peertask.Task, expCount int) {
+		tracker := New(partner)
+		var popped []peertask.Task
+		for _, task := range tasks {
+			// Push the task
+			tracker.PushTasks([]peertask.Task{task})
+			// Pop the task (which makes it active)
+			popped = append(popped, tracker.PopTasks(10)...)
+		}
+		if len(popped) != expCount {
+			t.Fatalf("Expected %d tasks, received %d tasks", expCount, len(popped))
+		}
+	}
+
+	// should ignore second want-have
+	runTestCase([]peertask.Task{wantHave, wantHave}, 1)
+	// should ignore second want-block
+	runTestCase([]peertask.Task{wantBlock, wantBlock}, 1)
+	// want-have does not overwrite want-block
+	runTestCase([]peertask.Task{wantBlock, wantHave}, 1)
+	// can't replace want-have with want-block because want-have is active
+	runTestCase([]peertask.Task{wantHave, wantBlock}, 2)
+}
+
+func TestTaskDone(t *testing.T) {
+	partner := testutil.GeneratePeers(1)[0]
+
+	wantHave := peertask.Task{
+		Identifier:   "1",
+		Priority:     10,
+		IsWantBlock:  false,
+		IsDontHave:   false,
+		SendDontHave: false,
+		Size:         10,
+	}
+	wantBlock := peertask.Task{
+		Identifier:   "1",
+		Priority:     10,
+		IsWantBlock:  true,
+		IsDontHave:   false,
+		SendDontHave: false,
+		Size:         10,
+	}
+
+	runTestCase := func(tasks []peertask.Task, expCount int) {
+		tracker := New(partner)
+		var popped []peertask.Task
+		for _, task := range tasks {
+			// Push the task
+			tracker.PushTasks([]peertask.Task{task})
+			// Pop the task (which makes it active)
+			poppedTask := tracker.PopTasks(10)
+			if len(poppedTask) > 0 {
+				popped = append(popped, poppedTask...)
+				// Complete the task (which makes it inactive)
+				tracker.TaskDone(poppedTask[0].Identifier, poppedTask[0].IsWantBlock)
+			}
+		}
+		if len(popped) != expCount {
+			t.Fatalf("Expected %d tasks, received %d tasks", expCount, len(popped))
+		}
+	}
+
+	// should allow second want-have after first is complete
+	runTestCase([]peertask.Task{wantHave, wantHave}, 2)
+	// should allow second want-block after first is complete
+	runTestCase([]peertask.Task{wantBlock, wantBlock}, 2)
+	// should allow want-have after want-block is complete
+	runTestCase([]peertask.Task{wantBlock, wantHave}, 2)
+	// should allow want-block after want-have is complete
+	runTestCase([]peertask.Task{wantHave, wantBlock}, 2)
+}

--- a/peertracker/peertracker_test.go
+++ b/peertracker/peertracker_test.go
@@ -527,7 +527,7 @@ func TestTaskDone(t *testing.T) {
 			if len(poppedTask) > 0 {
 				popped = append(popped, poppedTask...)
 				// Complete the task (which makes it inactive)
-				tracker.TaskDone(poppedTask[0].Identifier, poppedTask[0].IsWantBlock)
+				tracker.TaskDone(poppedTask[0])
 			}
 		}
 		if len(popped) != expCount {

--- a/peertracker/peertracker_test.go
+++ b/peertracker/peertracker_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestEmpty(t *testing.T) {
 	partner := testutil.GeneratePeers(1)[0]
-	tracker := New(partner)
+	tracker := New(partner, &DefaultTaskMerger{})
 
 	if len(tracker.PopTasks(100)) != 0 {
 		t.Fatal("Expected no tasks")
@@ -18,17 +18,13 @@ func TestEmpty(t *testing.T) {
 
 func TestPushPop(t *testing.T) {
 	partner := testutil.GeneratePeers(1)[0]
-	tracker := New(partner)
+	tracker := New(partner, &DefaultTaskMerger{})
 
 	tasks := []peertask.Task{
 		peertask.Task{
-			Identifier:   "1",
-			Priority:     1,
-			IsWantBlock:  true,
-			BlockSize:    10,
-			HaveBlock:    true,
-			EntrySize:    10,
-			SendDontHave: false,
+			Topic:    "1",
+			Priority: 1,
+			Size:     10,
 		},
 	}
 	tracker.PushTasks(tasks)
@@ -36,24 +32,20 @@ func TestPushPop(t *testing.T) {
 	if len(popped) != 1 {
 		t.Fatal("Expected 1 task")
 	}
-	if popped[0].Identifier != "1" {
+	if popped[0].Topic != "1" {
 		t.Fatal("Expected same task")
 	}
 }
 
 func TestPopNegativeOrZeroSize(t *testing.T) {
 	partner := testutil.GeneratePeers(1)[0]
-	tracker := New(partner)
+	tracker := New(partner, &DefaultTaskMerger{})
 
 	tasks := []peertask.Task{
 		peertask.Task{
-			Identifier:   "1",
-			Priority:     1,
-			IsWantBlock:  true,
-			BlockSize:    10,
-			HaveBlock:    true,
-			EntrySize:    10,
-			SendDontHave: false,
+			Topic:    "1",
+			Priority: 1,
+			Size:     10,
 		},
 	}
 	tracker.PushTasks(tasks)
@@ -69,35 +61,23 @@ func TestPopNegativeOrZeroSize(t *testing.T) {
 
 func TestPushPopSizeAndOrder(t *testing.T) {
 	partner := testutil.GeneratePeers(1)[0]
-	tracker := New(partner)
+	tracker := New(partner, &DefaultTaskMerger{})
 
 	tasks := []peertask.Task{
 		peertask.Task{
-			Identifier:   "1",
-			Priority:     10,
-			IsWantBlock:  true,
-			BlockSize:    10,
-			HaveBlock:    true,
-			EntrySize:    10,
-			SendDontHave: false,
+			Topic:    "1",
+			Priority: 10,
+			Size:     10,
 		},
 		peertask.Task{
-			Identifier:   "2",
-			Priority:     20,
-			IsWantBlock:  true,
-			BlockSize:    10,
-			HaveBlock:    true,
-			EntrySize:    10,
-			SendDontHave: false,
+			Topic:    "2",
+			Priority: 20,
+			Size:     10,
 		},
 		peertask.Task{
-			Identifier:   "3",
-			Priority:     15,
-			IsWantBlock:  true,
-			BlockSize:    10,
-			HaveBlock:    true,
-			EntrySize:    10,
-			SendDontHave: false,
+			Topic:    "3",
+			Priority: 15,
+			Size:     10,
 		},
 	}
 	tracker.PushTasks(tasks)
@@ -110,7 +90,7 @@ func TestPushPopSizeAndOrder(t *testing.T) {
 	if len(popped) != 1 {
 		t.Fatal("Expected 1 task")
 	}
-	if popped[0].Identifier != "2" {
+	if popped[0].Topic != "2" {
 		t.Fatal("Expected tasks in order")
 	}
 
@@ -118,7 +98,7 @@ func TestPushPopSizeAndOrder(t *testing.T) {
 	if len(popped) != 2 {
 		t.Fatal("Expected 2 tasks")
 	}
-	if popped[0].Identifier != "3" || popped[1].Identifier != "1" {
+	if popped[0].Topic != "3" || popped[1].Topic != "1" {
 		t.Fatal("Expected tasks in order")
 	}
 
@@ -130,35 +110,23 @@ func TestPushPopSizeAndOrder(t *testing.T) {
 
 func TestRemove(t *testing.T) {
 	partner := testutil.GeneratePeers(1)[0]
-	tracker := New(partner)
+	tracker := New(partner, &DefaultTaskMerger{})
 
 	tasks := []peertask.Task{
 		peertask.Task{
-			Identifier:   "1",
-			Priority:     10,
-			IsWantBlock:  true,
-			BlockSize:    10,
-			HaveBlock:    true,
-			EntrySize:    10,
-			SendDontHave: false,
+			Topic:    "1",
+			Priority: 10,
+			Size:     10,
 		},
 		peertask.Task{
-			Identifier:   "2",
-			Priority:     20,
-			IsWantBlock:  true,
-			BlockSize:    10,
-			HaveBlock:    true,
-			EntrySize:    10,
-			SendDontHave: false,
+			Topic:    "2",
+			Priority: 20,
+			Size:     10,
 		},
 		peertask.Task{
-			Identifier:   "3",
-			Priority:     15,
-			IsWantBlock:  true,
-			BlockSize:    10,
-			HaveBlock:    true,
-			EntrySize:    10,
-			SendDontHave: false,
+			Topic:    "3",
+			Priority: 15,
+			Size:     10,
 		},
 	}
 	tracker.PushTasks(tasks)
@@ -167,42 +135,30 @@ func TestRemove(t *testing.T) {
 	if len(popped) != 2 {
 		t.Fatal("Expected 2 tasks")
 	}
-	if popped[0].Identifier != "3" || popped[1].Identifier != "1" {
+	if popped[0].Topic != "3" || popped[1].Topic != "1" {
 		t.Fatal("Expected tasks in order")
 	}
 }
 
 func TestRemoveMulti(t *testing.T) {
 	partner := testutil.GeneratePeers(1)[0]
-	tracker := New(partner)
+	tracker := New(partner, &DefaultTaskMerger{})
 
 	tasks := []peertask.Task{
 		peertask.Task{
-			Identifier:   "1",
-			Priority:     10,
-			IsWantBlock:  true,
-			BlockSize:    10,
-			EntrySize:    10,
-			HaveBlock:    true,
-			SendDontHave: false,
+			Topic:    "1",
+			Priority: 10,
+			Size:     10,
 		},
 		peertask.Task{
-			Identifier:   "1",
-			Priority:     20,
-			IsWantBlock:  false,
-			BlockSize:    10,
-			HaveBlock:    true,
-			EntrySize:    1,
-			SendDontHave: false,
+			Topic:    "1",
+			Priority: 20,
+			Size:     1,
 		},
 		peertask.Task{
-			Identifier:   "2",
-			Priority:     15,
-			IsWantBlock:  true,
-			BlockSize:    10,
-			HaveBlock:    true,
-			EntrySize:    10,
-			SendDontHave: false,
+			Topic:    "2",
+			Priority: 15,
+			Size:     10,
 		},
 	}
 	tracker.PushTasks(tasks)
@@ -211,460 +167,313 @@ func TestRemoveMulti(t *testing.T) {
 	if len(popped) != 1 {
 		t.Fatal("Expected 1 task")
 	}
-	if popped[0].Identifier != "2" {
+	if popped[0].Topic != "2" {
 		t.Fatal("Expected remaining task")
-	}
-}
-
-func TestRemoveActive(t *testing.T) {
-	partner := testutil.GeneratePeers(1)[0]
-	tracker := New(partner)
-
-	tasks := []peertask.Task{
-		peertask.Task{
-			Identifier:   "1",
-			Priority:     10,
-			IsWantBlock:  true,
-			BlockSize:    10,
-			HaveBlock:    true,
-			EntrySize:    10,
-			SendDontHave: false,
-		},
-		peertask.Task{
-			Identifier:   "1",
-			Priority:     20,
-			IsWantBlock:  true,
-			BlockSize:    10,
-			HaveBlock:    true,
-			EntrySize:    1,
-			SendDontHave: false,
-		},
-		peertask.Task{
-			Identifier:   "2",
-			Priority:     15,
-			IsWantBlock:  true,
-			BlockSize:    10,
-			HaveBlock:    true,
-			EntrySize:    10,
-			SendDontHave: false,
-		},
-	}
-
-	tracker.PushTasks(tasks)
-
-	// Pop highest priority task, ie ID "1" want-have
-	// This makes the task active
-	popped := tracker.PopTasks(10)
-	if len(popped) != 1 {
-		t.Fatal("Expected 1 task")
-	}
-	if popped[0].Identifier != "1" {
-		t.Fatal("Expected tasks in order")
-	}
-
-	// Remove all tasks with ID "1"
-	tracker.Remove("1")
-	popped = tracker.PopTasks(100)
-	if len(popped) != 1 {
-		t.Fatal("Expected 1 task")
-	}
-	if popped[0].Identifier != "2" {
-		t.Fatal("Expected tasks in order")
-	}
-}
-
-func TestPushHaveVsBlock(t *testing.T) {
-	partner := testutil.GeneratePeers(1)[0]
-
-	wantHave := peertask.Task{
-		Identifier:   "1",
-		Priority:     10,
-		IsWantBlock:  false,
-		BlockSize:    10,
-		HaveBlock:    true,
-		EntrySize:    1,
-		SendDontHave: false,
-	}
-	wantBlock := peertask.Task{
-		Identifier:   "1",
-		Priority:     10,
-		IsWantBlock:  true,
-		BlockSize:    10,
-		HaveBlock:    true,
-		EntrySize:    10,
-		SendDontHave: false,
-	}
-
-	runTestCase := func(tasks []peertask.Task, expIsWantBlock bool) {
-		tracker := New(partner)
-		tracker.PushTasks(tasks)
-		popped := tracker.PopTasks(100)
-		if len(popped) != 1 {
-			t.Fatalf("Expected 1 task, received %d tasks", len(popped))
-		}
-		if popped[0].IsWantBlock != expIsWantBlock {
-			t.Fatalf("Expected task.IsWantBlock to be %t, received %t", expIsWantBlock, popped[0].IsWantBlock)
-		}
-	}
-	const wantBlockType = true
-	const wantHaveType = false
-
-	// should ignore second want-have
-	runTestCase([]peertask.Task{wantHave, wantHave}, wantHaveType)
-	// should ignore second want-block
-	runTestCase([]peertask.Task{wantBlock, wantBlock}, wantBlockType)
-	// want-have does not overwrite want-block
-	runTestCase([]peertask.Task{wantBlock, wantHave}, wantBlockType)
-	// want-block overwrites want-have
-	runTestCase([]peertask.Task{wantHave, wantBlock}, wantBlockType)
-}
-
-func TestPushSizeInfo(t *testing.T) {
-	partner := testutil.GeneratePeers(1)[0]
-
-	wantBlock := peertask.Task{
-		Identifier:   "1",
-		Priority:     10,
-		IsWantBlock:  true,
-		BlockSize:    10,
-		HaveBlock:    true,
-		EntrySize:    10,
-		SendDontHave: false,
-	}
-	wantBlockDontHave := peertask.Task{
-		Identifier:   "1",
-		Priority:     10,
-		IsWantBlock:  true,
-		BlockSize:    0,
-		HaveBlock:    false,
-		EntrySize:    2,
-		SendDontHave: false,
-	}
-	wantHave := peertask.Task{
-		Identifier:   "1",
-		Priority:     10,
-		IsWantBlock:  false,
-		BlockSize:    10,
-		HaveBlock:    true,
-		EntrySize:    1,
-		SendDontHave: false,
-	}
-	wantHaveDontHave := peertask.Task{
-		Identifier:   "1",
-		Priority:     10,
-		IsWantBlock:  false,
-		BlockSize:    0,
-		HaveBlock:    false,
-		EntrySize:    1,
-		SendDontHave: false,
-	}
-
-	runTestCase := func(tasks []peertask.Task, expEntrySize int, expBlockSize int, expIsWantBlock bool) {
-		tracker := New(partner)
-		tracker.PushTasks(tasks)
-		popped := tracker.PopTasks(100)
-		if len(popped) != 1 {
-			t.Fatalf("Expected 1 task, received %d tasks", len(popped))
-		}
-		if popped[0].EntrySize != expEntrySize {
-			t.Fatalf("Expected task.EntrySize to be %d, received %d", expEntrySize, popped[0].EntrySize)
-		}
-		if popped[0].BlockSize != expBlockSize {
-			t.Fatalf("Expected task.EntrySize to be %d, received %d", expBlockSize, popped[0].BlockSize)
-		}
-		if popped[0].IsWantBlock != expIsWantBlock {
-			t.Fatalf("Expected task.IsWantBlock to be %t, received %t", expIsWantBlock, popped[0].IsWantBlock)
-		}
-	}
-
-	isWantBlock := true
-	isWantHave := false
-
-	// want-block (DONT_HAVE) should have no effect on existing want-block (DONT_HAVE)
-	runTestCase([]peertask.Task{wantBlockDontHave, wantBlockDontHave}, wantBlockDontHave.EntrySize, wantBlockDontHave.BlockSize, isWantBlock)
-	// want-have (DONT_HAVE) should have no effect on existing want-block (DONT_HAVE)
-	runTestCase([]peertask.Task{wantBlockDontHave, wantHaveDontHave}, wantBlockDontHave.EntrySize, wantBlockDontHave.BlockSize, isWantBlock)
-	// want-block with size should update existing want-block (DONT_HAVE)
-	runTestCase([]peertask.Task{wantBlockDontHave, wantBlock}, wantBlock.EntrySize, wantBlock.BlockSize, isWantBlock)
-	// want-have with size should update existing want-block (DONT_HAVE) size,
-	// but leave it as a want-block (ie should not change it to want-have)
-	runTestCase([]peertask.Task{wantBlockDontHave, wantHave}, wantHave.BlockSize, wantHave.BlockSize, isWantBlock)
-
-	// want-block (DONT_HAVE) size should not update existing want-block with size
-	runTestCase([]peertask.Task{wantBlock, wantBlockDontHave}, wantBlock.EntrySize, wantBlock.BlockSize, isWantBlock)
-	// want-have (DONT_HAVE) should have no effect on existing want-block with size
-	runTestCase([]peertask.Task{wantBlock, wantHaveDontHave}, wantBlock.EntrySize, wantBlock.BlockSize, isWantBlock)
-	// want-block with size should have no effect on existing want-block with size
-	runTestCase([]peertask.Task{wantBlock, wantBlock}, wantBlock.EntrySize, wantBlock.BlockSize, isWantBlock)
-	// want-have with size should have no effect on existing want-block with size
-	runTestCase([]peertask.Task{wantBlock, wantHave}, wantBlock.EntrySize, wantBlock.BlockSize, isWantBlock)
-
-	// want-block (DONT_HAVE) should update type and entry size of existing want-have (DONT_HAVE)
-	runTestCase([]peertask.Task{wantHaveDontHave, wantBlockDontHave}, wantBlockDontHave.EntrySize, wantBlockDontHave.BlockSize, isWantBlock)
-	// want-have (DONT_HAVE) should have no effect on existing want-have (DONT_HAVE)
-	runTestCase([]peertask.Task{wantHaveDontHave, wantHaveDontHave}, wantHaveDontHave.EntrySize, wantHaveDontHave.BlockSize, isWantHave)
-	// want-block with size should update existing want-have (DONT_HAVE)
-	runTestCase([]peertask.Task{wantHaveDontHave, wantBlock}, wantBlock.EntrySize, wantBlock.BlockSize, isWantBlock)
-	// want-have with size should update existing want-have (DONT_HAVE)
-	runTestCase([]peertask.Task{wantHaveDontHave, wantHave}, wantHave.EntrySize, wantHave.BlockSize, isWantHave)
-
-	// want-block (DONT_HAVE) should update type and entry size of existing want-have with size
-	runTestCase([]peertask.Task{wantHave, wantBlockDontHave}, wantHave.BlockSize, wantHave.BlockSize, isWantBlock)
-	// want-have (DONT_HAVE) should not update existing want-have with size
-	runTestCase([]peertask.Task{wantHave, wantHaveDontHave}, wantHave.EntrySize, wantHave.BlockSize, isWantHave)
-	// want-block with size should update type and entry size of existing want-have with size
-	runTestCase([]peertask.Task{wantHave, wantBlock}, wantBlock.EntrySize, wantBlock.BlockSize, isWantBlock)
-	// want-have should have no effect on existing want-have
-	runTestCase([]peertask.Task{wantHave, wantHave}, wantHave.EntrySize, wantHave.BlockSize, isWantHave)
-}
-
-func TestPushHaveVsBlockActive(t *testing.T) {
-	partner := testutil.GeneratePeers(1)[0]
-
-	wantBlock := peertask.Task{
-		Identifier:   "1",
-		Priority:     10,
-		IsWantBlock:  true,
-		BlockSize:    10,
-		HaveBlock:    true,
-		EntrySize:    10,
-		SendDontHave: false,
-	}
-	wantHave := peertask.Task{
-		Identifier:   "1",
-		Priority:     10,
-		IsWantBlock:  false,
-		BlockSize:    10,
-		HaveBlock:    true,
-		EntrySize:    1,
-		SendDontHave: false,
-	}
-
-	runTestCase := func(tasks []peertask.Task, expCount int) {
-		tracker := New(partner)
-		var popped []peertask.Task
-		for _, task := range tasks {
-			// Push the task
-			tracker.PushTasks([]peertask.Task{task})
-			// Pop the task (which makes it active)
-			popped = append(popped, tracker.PopTasks(10)...)
-		}
-		if len(popped) != expCount {
-			t.Fatalf("Expected %d tasks, received %d tasks", expCount, len(popped))
-		}
-	}
-
-	// should ignore second want-have
-	runTestCase([]peertask.Task{wantHave, wantHave}, 1)
-	// should ignore second want-block
-	runTestCase([]peertask.Task{wantBlock, wantBlock}, 1)
-	// want-have does not overwrite want-block
-	runTestCase([]peertask.Task{wantBlock, wantHave}, 1)
-	// can't replace want-have with want-block because want-have is active
-	runTestCase([]peertask.Task{wantHave, wantBlock}, 2)
-}
-
-func TestPushSizeInfoActive(t *testing.T) {
-	partner := testutil.GeneratePeers(1)[0]
-
-	wantBlock := peertask.Task{
-		Identifier:   "1",
-		Priority:     10,
-		IsWantBlock:  true,
-		BlockSize:    10,
-		HaveBlock:    true,
-		EntrySize:    10,
-		SendDontHave: false,
-	}
-	wantBlockDontHave := peertask.Task{
-		Identifier:   "1",
-		Priority:     10,
-		IsWantBlock:  true,
-		BlockSize:    0,
-		HaveBlock:    false,
-		EntrySize:    2,
-		SendDontHave: false,
-	}
-	wantHave := peertask.Task{
-		Identifier:   "1",
-		Priority:     10,
-		IsWantBlock:  false,
-		BlockSize:    10,
-		HaveBlock:    true,
-		EntrySize:    1,
-		SendDontHave: false,
-	}
-	wantHaveDontHave := peertask.Task{
-		Identifier:   "1",
-		Priority:     10,
-		IsWantBlock:  false,
-		BlockSize:    0,
-		HaveBlock:    false,
-		EntrySize:    1,
-		SendDontHave: false,
-	}
-
-	runTestCase := func(tasks []peertask.Task, expTasks []peertask.Task) {
-		tracker := New(partner)
-		var popped []peertask.Task
-		for _, task := range tasks {
-			// Push the task
-			tracker.PushTasks([]peertask.Task{task})
-			// Pop the task (which makes it active)
-			popped = append(popped, tracker.PopTasks(100)...)
-		}
-		if len(popped) != len(expTasks) {
-			t.Fatalf("Expected %d tasks, received %d tasks", len(expTasks), len(popped))
-		}
-		for i, task := range popped {
-			if task.IsWantBlock != expTasks[i].IsWantBlock {
-				t.Fatalf("Expected IsWantBlock to be %t, received %t", expTasks[i].IsWantBlock, task.IsWantBlock)
-			}
-			if task.EntrySize != expTasks[i].EntrySize {
-				t.Fatalf("Expected Size to be %d, received %d", expTasks[i].EntrySize, task.EntrySize)
-			}
-		}
-	}
-
-	// second want-block (DONT_HAVE) should be ignored
-	runTestCase([]peertask.Task{wantBlockDontHave, wantBlockDontHave}, []peertask.Task{wantBlockDontHave})
-	// want-have (DONT_HAVE) should be ignored if there is existing active want-block (DONT_HAVE)
-	runTestCase([]peertask.Task{wantBlockDontHave, wantHaveDontHave}, []peertask.Task{wantBlockDontHave})
-	// want-block with size should be added if there is existing active want-block (DONT_HAVE)
-	runTestCase([]peertask.Task{wantBlockDontHave, wantBlock}, []peertask.Task{wantBlockDontHave, wantBlock})
-	// want-have with size should be added if there is existing active want-block (DONT_HAVE)
-	runTestCase([]peertask.Task{wantBlockDontHave, wantHave}, []peertask.Task{wantBlockDontHave, wantHave})
-
-	// want-block (DONT_HAVE) should be added if there is existing active want-have (DONT_HAVE)
-	runTestCase([]peertask.Task{wantHaveDontHave, wantBlockDontHave}, []peertask.Task{wantHaveDontHave, wantBlockDontHave})
-	// want-have (DONT_HAVE) should be ignored if there is existing active want-have (DONT_HAVE)
-	runTestCase([]peertask.Task{wantHaveDontHave, wantHaveDontHave}, []peertask.Task{wantHaveDontHave})
-	// want-block with size should be added if there is existing active want-have (DONT_HAVE)
-	runTestCase([]peertask.Task{wantHaveDontHave, wantBlock}, []peertask.Task{wantHaveDontHave, wantBlock})
-	// want-have with size should be added if there is existing active want-have (DONT_HAVE)
-	runTestCase([]peertask.Task{wantHaveDontHave, wantHave}, []peertask.Task{wantHaveDontHave, wantHave})
-
-	// want-block (DONT_HAVE) should be ignored if there is existing active want-block with size
-	runTestCase([]peertask.Task{wantBlock, wantBlockDontHave}, []peertask.Task{wantBlock})
-	// want-have (DONT_HAVE) should be ignored if there is existing active want-block with size
-	runTestCase([]peertask.Task{wantBlock, wantHaveDontHave}, []peertask.Task{wantBlock})
-	// second want-block with size should be ignored
-	runTestCase([]peertask.Task{wantBlock, wantBlock}, []peertask.Task{wantBlock})
-	// want-have with size should be ignored if there is existing active want-block with size
-	runTestCase([]peertask.Task{wantBlock, wantHave}, []peertask.Task{wantBlock})
-
-	// want-block (DONT_HAVE) should be added if there is existing active want-have with size
-	runTestCase([]peertask.Task{wantHave, wantBlockDontHave}, []peertask.Task{wantHave, wantBlockDontHave})
-	// want-have (DONT_HAVE) should be ignored if there is existing active want-have with size
-	runTestCase([]peertask.Task{wantHave, wantHaveDontHave}, []peertask.Task{wantHave})
-	// second want-have with size should be ignored
-	runTestCase([]peertask.Task{wantHave, wantHave}, []peertask.Task{wantHave})
-	// want-block with size should be added if there is existing active want-have with size
-	runTestCase([]peertask.Task{wantHave, wantBlock}, []peertask.Task{wantHave, wantBlock})
-}
-
-func TestReplaceTaskThatIsActiveAndPending(t *testing.T) {
-	partner := testutil.GeneratePeers(1)[0]
-
-	wantBlock := peertask.Task{
-		Identifier:   "1",
-		Priority:     10,
-		IsWantBlock:  true,
-		BlockSize:    10,
-		HaveBlock:    true,
-		EntrySize:    10,
-		SendDontHave: false,
-	}
-	wantHave := peertask.Task{
-		Identifier:   "1",
-		Priority:     10,
-		IsWantBlock:  false,
-		BlockSize:    10,
-		HaveBlock:    true,
-		EntrySize:    1,
-		SendDontHave: false,
-	}
-	wantHaveDontHave := peertask.Task{
-		Identifier:   "1",
-		Priority:     10,
-		IsWantBlock:  false,
-		BlockSize:    0,
-		HaveBlock:    false,
-		EntrySize:    1,
-		SendDontHave: false,
-	}
-
-	tracker := New(partner)
-
-	// Push a want-have (DONT_HAVE)
-	tracker.PushTasks([]peertask.Task{wantHaveDontHave})
-
-	// Pop the want-have (DONT_HAVE) (which makes it active)
-	_ = tracker.PopTasks(20)
-
-	// Push a second want-have (with a size). Should be added to the pending
-	// queue.
-	tracker.PushTasks([]peertask.Task{wantHave})
-
-	// Push a want-block (should replace the pending want-have)
-	tracker.PushTasks([]peertask.Task{wantBlock})
-
-	popped := tracker.PopTasks(100)
-	if len(popped) != 1 {
-		t.Fatalf("Expected 1 task to be popped, received %d tasks", len(popped))
-	}
-	if !popped[0].IsWantBlock {
-		t.Fatalf("Expected task to be want-block")
 	}
 }
 
 func TestTaskDone(t *testing.T) {
 	partner := testutil.GeneratePeers(1)[0]
+	tracker := New(partner, &DefaultTaskMerger{})
 
-	wantBlock := peertask.Task{
-		Identifier:   "1",
-		Priority:     10,
-		IsWantBlock:  true,
-		BlockSize:    10,
-		HaveBlock:    true,
-		EntrySize:    10,
-		SendDontHave: false,
-	}
-	wantHave := peertask.Task{
-		Identifier:   "1",
-		Priority:     10,
-		IsWantBlock:  false,
-		BlockSize:    10,
-		HaveBlock:    true,
-		EntrySize:    1,
-		SendDontHave: false,
+	tasks := []peertask.Task{
+		peertask.Task{
+			Topic:    "1",
+			Priority: 10,
+			Size:     10,
+			Data:     "a",
+		},
+		peertask.Task{
+			Topic:    "1",
+			Priority: 20,
+			Size:     10,
+			Data:     "b",
+		},
 	}
 
-	runTestCase := func(tasks []peertask.Task, expCount int) {
-		tracker := New(partner)
-		var popped []peertask.Task
-		for _, task := range tasks {
-			// Push the task
-			tracker.PushTasks([]peertask.Task{task})
-			// Pop the task (which makes it active)
-			poppedTask := tracker.PopTasks(10)
-			if len(poppedTask) > 0 {
-				popped = append(popped, poppedTask...)
-				// Complete the task (which makes it inactive)
-				tracker.TaskDone(poppedTask[0])
-			}
-		}
-		if len(popped) != expCount {
-			t.Fatalf("Expected %d tasks, received %d tasks", expCount, len(popped))
-		}
+	// Push task "a"
+	tracker.PushTasks([]peertask.Task{tasks[0]}) // Topic "1"
+
+	// Pop task "a". This makes the task active.
+	popped := tracker.PopTasks(10)
+	if len(popped) != 1 {
+		t.Fatal("Expected 1 task")
 	}
 
-	// should allow second want-have after first is complete
-	runTestCase([]peertask.Task{wantHave, wantHave}, 2)
-	// should allow second want-block after first is complete
-	runTestCase([]peertask.Task{wantBlock, wantBlock}, 2)
-	// should allow want-have after want-block is complete
-	runTestCase([]peertask.Task{wantBlock, wantHave}, 2)
-	// should allow want-block after want-have is complete
-	runTestCase([]peertask.Task{wantHave, wantBlock}, 2)
+	// Mark task "a" as done.
+	tracker.TaskDone(popped[0])
+
+	// Push task "b"
+	tracker.PushTasks([]peertask.Task{tasks[1]}) // Topic "1"
+
+	// Pop all tasks. Task "a" was done so task "b" should have been allowed to
+	// be added.
+	popped = tracker.PopTasks(100)
+	if len(popped) != 1 {
+		t.Fatal("Expected 1 task")
+	}
+}
+
+type permissiveTaskMerger struct{}
+
+func (*permissiveTaskMerger) HasNewInfo(task peertask.Task, existing []peertask.Task) bool {
+	return true
+}
+func (*permissiveTaskMerger) Merge(task peertask.Task, existing *peertask.Task) {
+	existing.Data = task.Data
+	existing.Size = task.Size
+}
+
+func TestReplaceTaskPermissive(t *testing.T) {
+	partner := testutil.GeneratePeers(1)[0]
+	tracker := New(partner, &permissiveTaskMerger{})
+
+	tasks := []peertask.Task{
+		peertask.Task{
+			Topic:    "1",
+			Priority: 10,
+			Size:     10,
+			Data:     "a",
+		},
+		peertask.Task{
+			Topic:    "1",
+			Priority: 20,
+			Size:     10,
+			Data:     "b",
+		},
+	}
+
+	// Push task "a"
+	tracker.PushTasks([]peertask.Task{tasks[0]}) // Topic "1"
+
+	// Push task "b". Has same topic and permissive task merger, so should
+	// replace task "a".
+	tracker.PushTasks([]peertask.Task{tasks[1]}) // Topic "1"
+
+	// Pop all tasks, should only be task "b".
+	popped := tracker.PopTasks(100)
+	if len(popped) != 1 {
+		t.Fatal("Expected 1 task")
+	}
+	if popped[0].Data != "b" {
+		t.Fatal("Expected b to replace a")
+	}
+	if popped[0].Priority != 20 {
+		t.Fatal("Expected higher Priority to replace lower Priority")
+	}
+}
+
+func TestReplaceTaskSize(t *testing.T) {
+	partner := testutil.GeneratePeers(1)[0]
+	tracker := New(partner, &permissiveTaskMerger{})
+
+	tasks := []peertask.Task{
+		peertask.Task{
+			Topic:    "1",
+			Priority: 10,
+			Size:     10,
+			Data:     "a",
+		},
+		peertask.Task{
+			Topic:    "1",
+			Priority: 20,
+			Size:     20,
+			Data:     "b",
+		},
+	}
+
+	// Push task "a"
+	tracker.PushTasks([]peertask.Task{tasks[0]}) // Topic "1"
+
+	// Push task "b". Has same topic and permissive task merger, so should
+	// replace task "a", including new size
+	tracker.PushTasks([]peertask.Task{tasks[1]}) // Topic "1"
+
+	// Pop with maxSize 10. Should not pop anything because Size is now 20.
+	popped := tracker.PopTasks(10)
+	if len(popped) != 0 {
+		t.Fatal("Expected no tasks")
+	}
+	popped = tracker.PopTasks(20)
+	if len(popped) != 1 {
+		t.Fatal("Expected 1 task")
+	}
+}
+
+func TestReplaceActiveTask(t *testing.T) {
+	partner := testutil.GeneratePeers(1)[0]
+	tracker := New(partner, &permissiveTaskMerger{})
+
+	tasks := []peertask.Task{
+		peertask.Task{
+			Topic:    "1",
+			Priority: 10,
+			Size:     10,
+			Data:     "a",
+		},
+		peertask.Task{
+			Topic:    "1",
+			Priority: 20,
+			Size:     10,
+			Data:     "b",
+		},
+	}
+
+	// Push task "a"
+	tracker.PushTasks([]peertask.Task{tasks[0]}) // Topic "1"
+
+	// Pop task "a". This makes the task active.
+	popped := tracker.PopTasks(10)
+	if len(popped) != 1 {
+		t.Fatal("Expected 1 task")
+	}
+
+	// Push task "b"
+	tracker.PushTasks([]peertask.Task{tasks[1]}) // Topic "1"
+
+	// Pop all tasks. Task "a" was active so task "b" should have been moved to
+	// the pending queue.
+	popped = tracker.PopTasks(100)
+	if len(popped) != 1 {
+		t.Fatal("Expected 1 task")
+	}
+}
+
+func TestReplaceActiveTaskNonPermissive(t *testing.T) {
+	partner := testutil.GeneratePeers(1)[0]
+	tracker := New(partner, &DefaultTaskMerger{})
+
+	tasks := []peertask.Task{
+		peertask.Task{
+			Topic:    "1",
+			Priority: 10,
+			Size:     10,
+			Data:     "a",
+		},
+		peertask.Task{
+			Topic:    "1",
+			Priority: 20,
+			Size:     10,
+			Data:     "b",
+		},
+	}
+
+	// Push task "a"
+	tracker.PushTasks([]peertask.Task{tasks[0]}) // Topic "1"
+
+	// Pop task "a". This makes the task active.
+	popped := tracker.PopTasks(10)
+	if len(popped) != 1 {
+		t.Fatal("Expected 1 task")
+	}
+
+	// Push task "b". Task merger is not permissive, so should ignore task "b".
+	tracker.PushTasks([]peertask.Task{tasks[1]}) // Topic "1"
+
+	// Pop all tasks.
+	popped = tracker.PopTasks(100)
+	if len(popped) != 0 {
+		t.Fatal("Expected no tasks")
+	}
+}
+
+func TestReplaceTaskThatIsActiveAndPending(t *testing.T) {
+	partner := testutil.GeneratePeers(1)[0]
+	tracker := New(partner, &permissiveTaskMerger{})
+
+	tasks := []peertask.Task{
+		peertask.Task{
+			Topic:    "1",
+			Priority: 10,
+			Size:     10,
+			Data:     "a",
+		},
+		peertask.Task{
+			Topic:    "1",
+			Priority: 10,
+			Size:     10,
+			Data:     "b",
+		},
+		peertask.Task{
+			Topic:    "1",
+			Priority: 10,
+			Size:     10,
+			Data:     "c",
+		},
+	}
+
+	// Push task "a"
+	tracker.PushTasks([]peertask.Task{tasks[0]}) // Topic "1"
+
+	// Pop task "a". This makes the task active.
+	popped := tracker.PopTasks(10)
+	if len(popped) != 1 {
+		t.Fatal("Expected 1 task")
+	}
+
+	// Push task "b". Same Topic so should be added to the pending queue.
+	tracker.PushTasks([]peertask.Task{tasks[1]}) // Topic "1"
+
+	// Push task "c". Permissive task merger so should replace pending task "b"
+	// with same Topic.
+	tracker.PushTasks([]peertask.Task{tasks[2]}) // Topic "1"
+
+	// Pop all tasks.
+	popped = tracker.PopTasks(100)
+	if len(popped) != 1 {
+		t.Fatal("Expected 1 task")
+	}
+	if popped[0].Data != "c" {
+		t.Fatalf("Expected last task to overwrite pending task")
+	}
+}
+
+func TestRemoveActive(t *testing.T) {
+	partner := testutil.GeneratePeers(1)[0]
+	tracker := New(partner, &permissiveTaskMerger{})
+
+	tasks := []peertask.Task{
+		peertask.Task{
+			Topic:    "1",
+			Priority: 10,
+			Size:     10,
+			Data:     "a",
+		},
+		peertask.Task{
+			Topic:    "1",
+			Priority: 20,
+			Size:     10,
+			Data:     "b",
+		},
+		peertask.Task{
+			Topic:    "2",
+			Priority: 15,
+			Size:     10,
+			Data:     "c",
+		},
+	}
+
+	// Push task "a"
+	tracker.PushTasks([]peertask.Task{tasks[0]}) // Topic "1"
+
+	// Pop task "a". This makes the task active.
+	popped := tracker.PopTasks(10)
+	if len(popped) != 1 {
+		t.Fatal("Expected 1 task")
+	}
+
+	// Push task "b" and "c"
+	tracker.PushTasks([]peertask.Task{tasks[1]}) // Topic "1"
+	tracker.PushTasks([]peertask.Task{tasks[2]}) // Topic "2"
+
+	// Remove all tasks with Topic "1".
+	// This should remove task "b" from the pending queue.
+	tracker.Remove("1")
+	popped = tracker.PopTasks(100)
+	if len(popped) != 1 {
+		t.Fatal("Expected 1 task")
+	}
+	if popped[0].Topic != "2" {
+		t.Fatal("Expected tasks in order")
+	}
 }

--- a/peertracker/peertracker_test.go
+++ b/peertracker/peertracker_test.go
@@ -26,6 +26,7 @@ func TestPushPop(t *testing.T) {
 			Priority:     1,
 			IsWantBlock:  true,
 			BlockSize:    10,
+			HaveBlock:    true,
 			EntrySize:    10,
 			SendDontHave: false,
 		},
@@ -50,6 +51,7 @@ func TestPopNegativeOrZeroSize(t *testing.T) {
 			Priority:     1,
 			IsWantBlock:  true,
 			BlockSize:    10,
+			HaveBlock:    true,
 			EntrySize:    10,
 			SendDontHave: false,
 		},
@@ -75,6 +77,7 @@ func TestPushPopSizeAndOrder(t *testing.T) {
 			Priority:     10,
 			IsWantBlock:  true,
 			BlockSize:    10,
+			HaveBlock:    true,
 			EntrySize:    10,
 			SendDontHave: false,
 		},
@@ -83,6 +86,7 @@ func TestPushPopSizeAndOrder(t *testing.T) {
 			Priority:     20,
 			IsWantBlock:  true,
 			BlockSize:    10,
+			HaveBlock:    true,
 			EntrySize:    10,
 			SendDontHave: false,
 		},
@@ -91,6 +95,7 @@ func TestPushPopSizeAndOrder(t *testing.T) {
 			Priority:     15,
 			IsWantBlock:  true,
 			BlockSize:    10,
+			HaveBlock:    true,
 			EntrySize:    10,
 			SendDontHave: false,
 		},
@@ -133,6 +138,7 @@ func TestRemove(t *testing.T) {
 			Priority:     10,
 			IsWantBlock:  true,
 			BlockSize:    10,
+			HaveBlock:    true,
 			EntrySize:    10,
 			SendDontHave: false,
 		},
@@ -141,6 +147,7 @@ func TestRemove(t *testing.T) {
 			Priority:     20,
 			IsWantBlock:  true,
 			BlockSize:    10,
+			HaveBlock:    true,
 			EntrySize:    10,
 			SendDontHave: false,
 		},
@@ -149,6 +156,7 @@ func TestRemove(t *testing.T) {
 			Priority:     15,
 			IsWantBlock:  true,
 			BlockSize:    10,
+			HaveBlock:    true,
 			EntrySize:    10,
 			SendDontHave: false,
 		},
@@ -175,6 +183,7 @@ func TestRemoveMulti(t *testing.T) {
 			IsWantBlock:  true,
 			BlockSize:    10,
 			EntrySize:    10,
+			HaveBlock:    true,
 			SendDontHave: false,
 		},
 		peertask.Task{
@@ -182,6 +191,7 @@ func TestRemoveMulti(t *testing.T) {
 			Priority:     20,
 			IsWantBlock:  false,
 			BlockSize:    10,
+			HaveBlock:    true,
 			EntrySize:    1,
 			SendDontHave: false,
 		},
@@ -190,6 +200,7 @@ func TestRemoveMulti(t *testing.T) {
 			Priority:     15,
 			IsWantBlock:  true,
 			BlockSize:    10,
+			HaveBlock:    true,
 			EntrySize:    10,
 			SendDontHave: false,
 		},
@@ -215,6 +226,7 @@ func TestRemoveActive(t *testing.T) {
 			Priority:     10,
 			IsWantBlock:  true,
 			BlockSize:    10,
+			HaveBlock:    true,
 			EntrySize:    10,
 			SendDontHave: false,
 		},
@@ -223,6 +235,7 @@ func TestRemoveActive(t *testing.T) {
 			Priority:     20,
 			IsWantBlock:  true,
 			BlockSize:    10,
+			HaveBlock:    true,
 			EntrySize:    1,
 			SendDontHave: false,
 		},
@@ -231,6 +244,7 @@ func TestRemoveActive(t *testing.T) {
 			Priority:     15,
 			IsWantBlock:  true,
 			BlockSize:    10,
+			HaveBlock:    true,
 			EntrySize:    10,
 			SendDontHave: false,
 		},
@@ -267,6 +281,7 @@ func TestPushHaveVsBlock(t *testing.T) {
 		Priority:     10,
 		IsWantBlock:  false,
 		BlockSize:    10,
+		HaveBlock:    true,
 		EntrySize:    1,
 		SendDontHave: false,
 	}
@@ -275,6 +290,7 @@ func TestPushHaveVsBlock(t *testing.T) {
 		Priority:     10,
 		IsWantBlock:  true,
 		BlockSize:    10,
+		HaveBlock:    true,
 		EntrySize:    10,
 		SendDontHave: false,
 	}
@@ -311,6 +327,7 @@ func TestPushSizeInfo(t *testing.T) {
 		Priority:     10,
 		IsWantBlock:  true,
 		BlockSize:    10,
+		HaveBlock:    true,
 		EntrySize:    10,
 		SendDontHave: false,
 	}
@@ -319,6 +336,7 @@ func TestPushSizeInfo(t *testing.T) {
 		Priority:     10,
 		IsWantBlock:  true,
 		BlockSize:    0,
+		HaveBlock:    false,
 		EntrySize:    2,
 		SendDontHave: false,
 	}
@@ -327,6 +345,7 @@ func TestPushSizeInfo(t *testing.T) {
 		Priority:     10,
 		IsWantBlock:  false,
 		BlockSize:    10,
+		HaveBlock:    true,
 		EntrySize:    1,
 		SendDontHave: false,
 	}
@@ -335,6 +354,7 @@ func TestPushSizeInfo(t *testing.T) {
 		Priority:     10,
 		IsWantBlock:  false,
 		BlockSize:    0,
+		HaveBlock:    false,
 		EntrySize:    1,
 		SendDontHave: false,
 	}
@@ -406,6 +426,7 @@ func TestPushHaveVsBlockActive(t *testing.T) {
 		Priority:     10,
 		IsWantBlock:  true,
 		BlockSize:    10,
+		HaveBlock:    true,
 		EntrySize:    10,
 		SendDontHave: false,
 	}
@@ -414,6 +435,7 @@ func TestPushHaveVsBlockActive(t *testing.T) {
 		Priority:     10,
 		IsWantBlock:  false,
 		BlockSize:    10,
+		HaveBlock:    true,
 		EntrySize:    1,
 		SendDontHave: false,
 	}
@@ -450,6 +472,7 @@ func TestPushSizeInfoActive(t *testing.T) {
 		Priority:     10,
 		IsWantBlock:  true,
 		BlockSize:    10,
+		HaveBlock:    true,
 		EntrySize:    10,
 		SendDontHave: false,
 	}
@@ -458,6 +481,7 @@ func TestPushSizeInfoActive(t *testing.T) {
 		Priority:     10,
 		IsWantBlock:  true,
 		BlockSize:    0,
+		HaveBlock:    false,
 		EntrySize:    2,
 		SendDontHave: false,
 	}
@@ -466,6 +490,7 @@ func TestPushSizeInfoActive(t *testing.T) {
 		Priority:     10,
 		IsWantBlock:  false,
 		BlockSize:    10,
+		HaveBlock:    true,
 		EntrySize:    1,
 		SendDontHave: false,
 	}
@@ -474,6 +499,7 @@ func TestPushSizeInfoActive(t *testing.T) {
 		Priority:     10,
 		IsWantBlock:  false,
 		BlockSize:    0,
+		HaveBlock:    false,
 		EntrySize:    1,
 		SendDontHave: false,
 	}
@@ -545,6 +571,7 @@ func TestReplaceTaskThatIsActiveAndPending(t *testing.T) {
 		Priority:     10,
 		IsWantBlock:  true,
 		BlockSize:    10,
+		HaveBlock:    true,
 		EntrySize:    10,
 		SendDontHave: false,
 	}
@@ -553,6 +580,7 @@ func TestReplaceTaskThatIsActiveAndPending(t *testing.T) {
 		Priority:     10,
 		IsWantBlock:  false,
 		BlockSize:    10,
+		HaveBlock:    true,
 		EntrySize:    1,
 		SendDontHave: false,
 	}
@@ -561,6 +589,7 @@ func TestReplaceTaskThatIsActiveAndPending(t *testing.T) {
 		Priority:     10,
 		IsWantBlock:  false,
 		BlockSize:    0,
+		HaveBlock:    false,
 		EntrySize:    1,
 		SendDontHave: false,
 	}
@@ -571,7 +600,7 @@ func TestReplaceTaskThatIsActiveAndPending(t *testing.T) {
 	tracker.PushTasks([]peertask.Task{wantHaveDontHave})
 
 	// Pop the want-have (DONT_HAVE) (which makes it active)
-	popped := tracker.PopTasks(20)
+	_ = tracker.PopTasks(20)
 
 	// Push a second want-have (with a size). Should be added to the pending
 	// queue.
@@ -580,7 +609,7 @@ func TestReplaceTaskThatIsActiveAndPending(t *testing.T) {
 	// Push a want-block (should replace the pending want-have)
 	tracker.PushTasks([]peertask.Task{wantBlock})
 
-	popped = tracker.PopTasks(100)
+	popped := tracker.PopTasks(100)
 	if len(popped) != 1 {
 		t.Fatalf("Expected 1 task to be popped, received %d tasks", len(popped))
 	}
@@ -597,6 +626,7 @@ func TestTaskDone(t *testing.T) {
 		Priority:     10,
 		IsWantBlock:  true,
 		BlockSize:    10,
+		HaveBlock:    true,
 		EntrySize:    10,
 		SendDontHave: false,
 	}
@@ -605,6 +635,7 @@ func TestTaskDone(t *testing.T) {
 		Priority:     10,
 		IsWantBlock:  false,
 		BlockSize:    10,
+		HaveBlock:    true,
 		EntrySize:    1,
 		SendDontHave: false,
 	}

--- a/peertracker/peertracker_test.go
+++ b/peertracker/peertracker_test.go
@@ -22,12 +22,12 @@ func TestPushPop(t *testing.T) {
 
 	tasks := []peertask.Task{
 		peertask.Task{
-			Identifier:   "1",
-			Priority:     1,
-			IsWantBlock:  true,
-			IsDontHave:   false,
-			SendDontHave: false,
-			Size:         10,
+			Identifier:    "1",
+			Priority:      1,
+			IsWantBlock:   true,
+			KnowBlockSize: true,
+			SendDontHave:  false,
+			Size:          10,
 		},
 	}
 	tracker.PushTasks(tasks)
@@ -46,28 +46,28 @@ func TestPushPopSizeAndOrder(t *testing.T) {
 
 	tasks := []peertask.Task{
 		peertask.Task{
-			Identifier:   "1",
-			Priority:     10,
-			IsWantBlock:  true,
-			IsDontHave:   false,
-			SendDontHave: false,
-			Size:         10,
+			Identifier:    "1",
+			Priority:      10,
+			IsWantBlock:   true,
+			KnowBlockSize: true,
+			SendDontHave:  false,
+			Size:          10,
 		},
 		peertask.Task{
-			Identifier:   "2",
-			Priority:     20,
-			IsWantBlock:  true,
-			IsDontHave:   false,
-			SendDontHave: false,
-			Size:         10,
+			Identifier:    "2",
+			Priority:      20,
+			IsWantBlock:   true,
+			KnowBlockSize: true,
+			SendDontHave:  false,
+			Size:          10,
 		},
 		peertask.Task{
-			Identifier:   "3",
-			Priority:     15,
-			IsWantBlock:  true,
-			IsDontHave:   false,
-			SendDontHave: false,
-			Size:         10,
+			Identifier:    "3",
+			Priority:      15,
+			IsWantBlock:   true,
+			KnowBlockSize: true,
+			SendDontHave:  false,
+			Size:          10,
 		},
 	}
 	tracker.PushTasks(tasks)
@@ -104,28 +104,28 @@ func TestRemove(t *testing.T) {
 
 	tasks := []peertask.Task{
 		peertask.Task{
-			Identifier:   "1",
-			Priority:     10,
-			IsWantBlock:  true,
-			IsDontHave:   false,
-			SendDontHave: false,
-			Size:         10,
+			Identifier:    "1",
+			Priority:      10,
+			IsWantBlock:   true,
+			KnowBlockSize: true,
+			SendDontHave:  false,
+			Size:          10,
 		},
 		peertask.Task{
-			Identifier:   "2",
-			Priority:     20,
-			IsWantBlock:  true,
-			IsDontHave:   false,
-			SendDontHave: false,
-			Size:         10,
+			Identifier:    "2",
+			Priority:      20,
+			IsWantBlock:   true,
+			KnowBlockSize: true,
+			SendDontHave:  false,
+			Size:          10,
 		},
 		peertask.Task{
-			Identifier:   "3",
-			Priority:     15,
-			IsWantBlock:  true,
-			IsDontHave:   false,
-			SendDontHave: false,
-			Size:         10,
+			Identifier:    "3",
+			Priority:      15,
+			IsWantBlock:   true,
+			KnowBlockSize: true,
+			SendDontHave:  false,
+			Size:          10,
 		},
 	}
 	tracker.PushTasks(tasks)
@@ -145,28 +145,28 @@ func TestRemoveMulti(t *testing.T) {
 
 	tasks := []peertask.Task{
 		peertask.Task{
-			Identifier:   "1",
-			Priority:     10,
-			IsWantBlock:  true,
-			IsDontHave:   false,
-			SendDontHave: false,
-			Size:         10,
+			Identifier:    "1",
+			Priority:      10,
+			IsWantBlock:   true,
+			KnowBlockSize: true,
+			SendDontHave:  false,
+			Size:          10,
 		},
 		peertask.Task{
-			Identifier:   "1",
-			Priority:     20,
-			IsWantBlock:  false,
-			IsDontHave:   false,
-			SendDontHave: false,
-			Size:         10,
+			Identifier:    "1",
+			Priority:      20,
+			IsWantBlock:   false,
+			KnowBlockSize: true,
+			SendDontHave:  false,
+			Size:          10,
 		},
 		peertask.Task{
-			Identifier:   "2",
-			Priority:     15,
-			IsWantBlock:  true,
-			IsDontHave:   false,
-			SendDontHave: false,
-			Size:         10,
+			Identifier:    "2",
+			Priority:      15,
+			IsWantBlock:   true,
+			KnowBlockSize: true,
+			SendDontHave:  false,
+			Size:          10,
 		},
 	}
 	tracker.PushTasks(tasks)
@@ -186,28 +186,28 @@ func TestRemoveActive(t *testing.T) {
 
 	tasks := []peertask.Task{
 		peertask.Task{
-			Identifier:   "1",
-			Priority:     10,
-			IsWantBlock:  true,
-			IsDontHave:   false,
-			SendDontHave: false,
-			Size:         10,
+			Identifier:    "1",
+			Priority:      10,
+			IsWantBlock:   true,
+			KnowBlockSize: true,
+			SendDontHave:  false,
+			Size:          10,
 		},
 		peertask.Task{
-			Identifier:   "1",
-			Priority:     20,
-			IsWantBlock:  false,
-			IsDontHave:   false,
-			SendDontHave: false,
-			Size:         10,
+			Identifier:    "1",
+			Priority:      20,
+			IsWantBlock:   false,
+			KnowBlockSize: true,
+			SendDontHave:  false,
+			Size:          10,
 		},
 		peertask.Task{
-			Identifier:   "2",
-			Priority:     15,
-			IsWantBlock:  true,
-			IsDontHave:   false,
-			SendDontHave: false,
-			Size:         10,
+			Identifier:    "2",
+			Priority:      15,
+			IsWantBlock:   true,
+			KnowBlockSize: true,
+			SendDontHave:  false,
+			Size:          10,
 		},
 	}
 
@@ -238,20 +238,20 @@ func TestPushHaveVsBlock(t *testing.T) {
 	partner := testutil.GeneratePeers(1)[0]
 
 	wantHave := peertask.Task{
-		Identifier:   "1",
-		Priority:     10,
-		IsWantBlock:  false,
-		IsDontHave:   false,
-		SendDontHave: false,
-		Size:         10,
+		Identifier:    "1",
+		Priority:      10,
+		IsWantBlock:   false,
+		KnowBlockSize: true,
+		SendDontHave:  false,
+		Size:          10,
 	}
 	wantBlock := peertask.Task{
-		Identifier:   "1",
-		Priority:     10,
-		IsWantBlock:  true,
-		IsDontHave:   false,
-		SendDontHave: false,
-		Size:         10,
+		Identifier:    "1",
+		Priority:      10,
+		IsWantBlock:   true,
+		KnowBlockSize: true,
+		SendDontHave:  false,
+		Size:          10,
 	}
 
 	runTestCase := func(tasks []peertask.Task, expIsWantBlock bool) {
@@ -282,36 +282,36 @@ func TestPushSizeInfo(t *testing.T) {
 	partner := testutil.GeneratePeers(1)[0]
 
 	wantBlock := peertask.Task{
-		Identifier:   "1",
-		Priority:     10,
-		IsWantBlock:  true,
-		IsDontHave:   false,
-		SendDontHave: false,
-		Size:         20,
+		Identifier:    "1",
+		Priority:      10,
+		IsWantBlock:   true,
+		KnowBlockSize: true,
+		SendDontHave:  false,
+		Size:          20,
 	}
 	wantBlockDontHave := peertask.Task{
-		Identifier:   "1",
-		Priority:     10,
-		IsWantBlock:  true,
-		IsDontHave:   true,
-		SendDontHave: false,
-		Size:         10,
+		Identifier:    "1",
+		Priority:      10,
+		IsWantBlock:   true,
+		KnowBlockSize: false,
+		SendDontHave:  false,
+		Size:          10,
 	}
 	wantHave := peertask.Task{
-		Identifier:   "1",
-		Priority:     10,
-		IsWantBlock:  false,
-		IsDontHave:   false,
-		SendDontHave: false,
-		Size:         30,
+		Identifier:    "1",
+		Priority:      10,
+		IsWantBlock:   false,
+		KnowBlockSize: true,
+		SendDontHave:  false,
+		Size:          30,
 	}
 	wantHaveDontHave := peertask.Task{
-		Identifier:   "1",
-		Priority:     10,
-		IsWantBlock:  false,
-		IsDontHave:   true,
-		SendDontHave: false,
-		Size:         10,
+		Identifier:    "1",
+		Priority:      10,
+		IsWantBlock:   false,
+		KnowBlockSize: false,
+		SendDontHave:  false,
+		Size:          10,
 	}
 
 	runTestCase := func(tasks []peertask.Task, expSize int) {
@@ -340,20 +340,20 @@ func TestPushHaveVsBlockActive(t *testing.T) {
 	partner := testutil.GeneratePeers(1)[0]
 
 	wantHave := peertask.Task{
-		Identifier:   "1",
-		Priority:     10,
-		IsWantBlock:  false,
-		IsDontHave:   false,
-		SendDontHave: false,
-		Size:         10,
+		Identifier:    "1",
+		Priority:      10,
+		IsWantBlock:   false,
+		KnowBlockSize: true,
+		SendDontHave:  false,
+		Size:          10,
 	}
 	wantBlock := peertask.Task{
-		Identifier:   "1",
-		Priority:     10,
-		IsWantBlock:  true,
-		IsDontHave:   false,
-		SendDontHave: false,
-		Size:         10,
+		Identifier:    "1",
+		Priority:      10,
+		IsWantBlock:   true,
+		KnowBlockSize: true,
+		SendDontHave:  false,
+		Size:          10,
 	}
 
 	runTestCase := func(tasks []peertask.Task, expCount int) {
@@ -384,36 +384,36 @@ func TestPushSizeInfoActive(t *testing.T) {
 	partner := testutil.GeneratePeers(1)[0]
 
 	wantBlock := peertask.Task{
-		Identifier:   "1",
-		Priority:     10,
-		IsWantBlock:  true,
-		IsDontHave:   false,
-		SendDontHave: false,
-		Size:         10,
+		Identifier:    "1",
+		Priority:      10,
+		IsWantBlock:   true,
+		KnowBlockSize: true,
+		SendDontHave:  false,
+		Size:          10,
 	}
 	wantBlockDontHave := peertask.Task{
-		Identifier:   "1",
-		Priority:     10,
-		IsWantBlock:  true,
-		IsDontHave:   true,
-		SendDontHave: false,
-		Size:         10,
+		Identifier:    "1",
+		Priority:      10,
+		IsWantBlock:   true,
+		KnowBlockSize: false,
+		SendDontHave:  false,
+		Size:          10,
 	}
 	wantHave := peertask.Task{
-		Identifier:   "1",
-		Priority:     10,
-		IsWantBlock:  false,
-		IsDontHave:   false,
-		SendDontHave: false,
-		Size:         10,
+		Identifier:    "1",
+		Priority:      10,
+		IsWantBlock:   false,
+		KnowBlockSize: true,
+		SendDontHave:  false,
+		Size:          10,
 	}
 	wantHaveDontHave := peertask.Task{
-		Identifier:   "1",
-		Priority:     10,
-		IsWantBlock:  false,
-		IsDontHave:   true,
-		SendDontHave: false,
-		Size:         10,
+		Identifier:    "1",
+		Priority:      10,
+		IsWantBlock:   false,
+		KnowBlockSize: false,
+		SendDontHave:  false,
+		Size:          10,
 	}
 
 	runTestCase := func(tasks []peertask.Task, expCount int) {
@@ -448,28 +448,28 @@ func TestReplaceTaskThatIsActiveAndPending(t *testing.T) {
 	partner := testutil.GeneratePeers(1)[0]
 
 	wantBlock := peertask.Task{
-		Identifier:   "1",
-		Priority:     10,
-		IsWantBlock:  true,
-		IsDontHave:   false,
-		SendDontHave: false,
-		Size:         10,
+		Identifier:    "1",
+		Priority:      10,
+		IsWantBlock:   true,
+		KnowBlockSize: true,
+		SendDontHave:  false,
+		Size:          10,
 	}
 	wantHave := peertask.Task{
-		Identifier:   "1",
-		Priority:     10,
-		IsWantBlock:  false,
-		IsDontHave:   false,
-		SendDontHave: false,
-		Size:         10,
+		Identifier:    "1",
+		Priority:      10,
+		IsWantBlock:   false,
+		KnowBlockSize: true,
+		SendDontHave:  false,
+		Size:          10,
 	}
 	wantHaveDontHave := peertask.Task{
-		Identifier:   "1",
-		Priority:     10,
-		IsWantBlock:  false,
-		IsDontHave:   true,
-		SendDontHave: false,
-		Size:         10,
+		Identifier:    "1",
+		Priority:      10,
+		IsWantBlock:   false,
+		KnowBlockSize: false,
+		SendDontHave:  false,
+		Size:          10,
 	}
 
 	tracker := New(partner)
@@ -500,20 +500,20 @@ func TestTaskDone(t *testing.T) {
 	partner := testutil.GeneratePeers(1)[0]
 
 	wantHave := peertask.Task{
-		Identifier:   "1",
-		Priority:     10,
-		IsWantBlock:  false,
-		IsDontHave:   false,
-		SendDontHave: false,
-		Size:         10,
+		Identifier:    "1",
+		Priority:      10,
+		IsWantBlock:   false,
+		KnowBlockSize: true,
+		SendDontHave:  false,
+		Size:          10,
 	}
 	wantBlock := peertask.Task{
-		Identifier:   "1",
-		Priority:     10,
-		IsWantBlock:  true,
-		IsDontHave:   false,
-		SendDontHave: false,
-		Size:         10,
+		Identifier:    "1",
+		Priority:      10,
+		IsWantBlock:   true,
+		KnowBlockSize: true,
+		SendDontHave:  false,
+		Size:          10,
 	}
 
 	runTestCase := func(tasks []peertask.Task, expCount int) {


### PR DESCRIPTION
The Bitswap proof-of-concept
- supports new message types
- pushes requests onto the request queue individually (instead of in groups)
- pulls requests off the request queue by size (instead of in pre-pushed groups)

This PR extends peer task queue to support Bitswap's requirements and
- orders peers by outstanding bytes (rather than number of blocks)

See https://github.com/ipfs/go-bitswap/issues/197