### PR TITLE
Add topic inspector

### DIFF
--- a/peertaskqueue.go
+++ b/peertaskqueue.go
@@ -191,6 +191,17 @@ func (ptq *PeerTaskQueue) Stats() *PeerTaskQueueStats {
 	return s
 }
 
+// PeerTopics returns all topics running on a specific peer
+func (ptq *PeerTaskQueue) PeerTopics(p peer.ID) *peertracker.PeerTrackerTopics {
+	ptq.lock.Lock()
+	defer ptq.lock.Unlock()
+	pt, ok := ptq.peerTrackers[p]
+	if !ok {
+		return nil
+	}
+	return pt.Topics()
+}
+
 // PushTasks adds a new group of tasks for the given peer to the queue
 func (ptq *PeerTaskQueue) PushTasks(to peer.ID, tasks ...peertask.Task) {
 	ptq.lock.Lock()

--- a/peertracker/peertracker.go
+++ b/peertracker/peertracker.go
@@ -171,6 +171,28 @@ func (p *PeerTracker) Stats() *PeerTrackerStats {
 	return &PeerTrackerStats{NumPending: len(p.pendingTasks), NumActive: len(p.activeTasks)}
 }
 
+// PeerTrackerTopics captures the current state of topics in this peers queue
+type PeerTrackerTopics struct {
+	Pending []peertask.Topic
+	Active  []peertask.Topic
+}
+
+// Topics gives a full list of current and active topics for this peer
+// Stats returns current statistics for this peer.
+func (p *PeerTracker) Topics() *PeerTrackerTopics {
+	p.activelk.Lock()
+	defer p.activelk.Unlock()
+	pending := make([]peertask.Topic, 0, len(p.pendingTasks))
+	for topic := range p.pendingTasks {
+		pending = append(pending, topic)
+	}
+	active := make([]peertask.Topic, 0, len(p.activeTasks))
+	for topic := range p.activeTasks {
+		active = append(active, topic)
+	}
+	return &PeerTrackerTopics{Pending: pending, Active: active}
+}
+
 // Index implements pq.Elem.
 func (p *PeerTracker) Index() int {
 	return p.index


### PR DESCRIPTION
# Goals

In Graphsync we are working to get more in depth diagnostics on ongoing requests for a given peer. One thing we'd like is to be able to get insight into is which requests are in the different peer tasks queues. This method adds a tool to get expose this information, primarily for debugging purposes in a higher level library.

# Implementation

- Define and add method on PeerTracker
- Expose in PeerTaskQueue